### PR TITLE
Enables filtering reservations by schedule ID

### DIFF
--- a/apps/members/members.py
+++ b/apps/members/members.py
@@ -109,14 +109,29 @@ def cancel_reservation(reservation_id: str) -> Reservation:
 
 
 def list_reservations_by_date_range(
-    *, start_date, end_date, member_id=None, instructor_id=None, room_id=None
+    *,
+    start_date=None,
+    end_date=None,
+    member_id=None,
+    schedule_id=None,
+    instructor_id=None,
+    room_id=None,
 ) -> QuerySet[Reservation]:
     """
     Return reservations filtered by schedule start date range and optional filters.
 
     Uses __range for date filtering (inclusive) as requested.
+    Can filter by schedule_id directly, or by date range with optional filters.
     """
-    filters = {"schedule__start_time__date__range": (start_date, end_date)}
+    filters = {}
+
+    # If schedule_id is provided, filter by it directly
+    if schedule_id is not None:
+        filters["schedule_id"] = schedule_id
+    # Otherwise, use date range if provided
+    elif start_date is not None and end_date is not None:
+        filters["schedule__start_time__date__range"] = (start_date, end_date)
+
     if member_id is not None:
         filters["member_id"] = member_id
     if instructor_id is not None:

--- a/apps/members/schemas.py
+++ b/apps/members/schemas.py
@@ -23,6 +23,5 @@ class ReservationSchema(BaseModel):
     schedule_id: uuid.UUID
     status: str
     spot: int | None = None
-    notes: str | None = None
 
     model_config = {"from_attributes": True}

--- a/apps/members/serializers.py
+++ b/apps/members/serializers.py
@@ -41,8 +41,25 @@ class ReservationSerializer(serializers.Serializer):
 
 
 class ReservationListQuerySerializer(serializers.Serializer):
-    start_date = serializers.DateField(required=True)
-    end_date = serializers.DateField(required=True)
+    start_date = serializers.DateField(required=False)
+    end_date = serializers.DateField(required=False)
     member_id = serializers.UUIDField(required=False)
+    schedule_id = serializers.UUIDField(required=False)
     schedule__instructor_id = serializers.UUIDField(required=False)
     schedule__room_id = serializers.UUIDField(required=False)
+
+    def validate(self, attrs):
+        """Validate that either schedule_id or both start_date and end_date are provided."""
+        schedule_id = attrs.get("schedule_id")
+        start_date = attrs.get("start_date")
+        end_date = attrs.get("end_date")
+
+        if not schedule_id and not (start_date and end_date):
+            raise serializers.ValidationError(
+                "Either 'schedule_id' or both 'start_date' and 'end_date' must be provided."
+            )
+
+        if start_date and end_date and start_date > end_date:
+            raise serializers.ValidationError("'start_date' must be before or equal to 'end_date'.")
+
+        return attrs

--- a/apps/members/services.py
+++ b/apps/members/services.py
@@ -38,5 +38,20 @@ def cancel_reservation(reservation_id: str) -> ReservationSchema:
 
 def list_reservations(validated_query: dict) -> list[ReservationSchema]:
     """Application service: list reservations via domain and return schemas."""
-    qs = members.list_reservations_by_date_range(**validated_query)
+    # Map serializer field names to function parameter names
+    query_params = {}
+    if "start_date" in validated_query:
+        query_params["start_date"] = validated_query["start_date"]
+    if "end_date" in validated_query:
+        query_params["end_date"] = validated_query["end_date"]
+    if "member_id" in validated_query:
+        query_params["member_id"] = validated_query["member_id"]
+    if "schedule_id" in validated_query:
+        query_params["schedule_id"] = validated_query["schedule_id"]
+    if "schedule__instructor_id" in validated_query:
+        query_params["instructor_id"] = validated_query["schedule__instructor_id"]
+    if "schedule__room_id" in validated_query:
+        query_params["room_id"] = validated_query["schedule__room_id"]
+
+    qs = members.list_reservations_by_date_range(**query_params)
     return [ReservationSchema.model_validate(obj) for obj in qs]

--- a/apps/members/tests/test_services.py
+++ b/apps/members/tests/test_services.py
@@ -173,7 +173,7 @@ class TestMembersServices:
             {
                 "start_date": start_date,
                 "end_date": end_date,
-                "instructor_id": str(instr2.id),
+                "schedule__instructor_id": str(instr2.id),
             }
         )
         assert {str(x.id) for x in res_instr} == {str(r2.id)}
@@ -183,7 +183,45 @@ class TestMembersServices:
             {
                 "start_date": start_date,
                 "end_date": end_date,
-                "room_id": str(room_a.id),
+                "schedule__room_id": str(room_a.id),
             }
         )
         assert {str(x.id) for x in res_room} == {str(r1.id)}
+
+    def test_list_reservations_filters_by_schedule_id(self):
+        User = get_user_model()
+        user_member = User.objects.create_user(
+            username=f"member_{uuid.uuid4()}", email=f"m_{uuid.uuid4()}@ex.com", password="pass"
+        )
+        member = Member.objects.create(user=user_member)
+        studio = Studio.objects.create(name="S4", address="Addr4", is_active=True)
+        room = Room.objects.create(studio=studio, name="R4", capacity=10, is_active=True)
+        instructor_user = User.objects.create_user(
+            username=f"instr_{uuid.uuid4()}", email=f"i4_{uuid.uuid4()}@ex.com", password="pass"
+        )
+        instructor = Instructor.objects.create(user=instructor_user)
+
+        base = timezone.now().replace(hour=9, minute=0, second=0, microsecond=0)
+        s1 = Schedule.objects.create(
+            instructor=instructor,
+            start_time=base,
+            duration_minutes=60,
+            room=room,
+        )
+        s2 = Schedule.objects.create(
+            instructor=instructor,
+            start_time=base + datetime.timedelta(days=1),
+            duration_minutes=60,
+            room=room,
+        )
+
+        r1 = Reservation.objects.create(member=member, schedule=s1)
+        r2 = Reservation.objects.create(member=member, schedule=s2)
+
+        # Filter by schedule_id - should only return reservations for s1
+        result = service_list_reservations({"schedule_id": str(s1.id)})
+
+        assert isinstance(result, list)
+        ids = {str(obj.id) for obj in result}
+        assert ids == {str(r1.id)}
+        assert str(result[0].schedule_id) == str(s1.id)

--- a/apps/members/tests/test_views.py
+++ b/apps/members/tests/test_views.py
@@ -439,9 +439,7 @@ class TestReservationsList:
         assert isinstance(resp.data, list)
         assert len(resp.data) == 2
         assert str(resp.data[0]["member_id"]) == str(member_id)
-        assert {"id", "schedule_id", "member_id", "status", "spot", "notes"}.issubset(
-            resp.data[0].keys()
-        )
+        assert {"id", "schedule_id", "member_id", "status", "spot"}.issubset(resp.data[0].keys())
 
     def test_list_returns_400_when_invalid_query(self, api_client):
         user = User.objects.create_user(

--- a/apps/schedules/services.py
+++ b/apps/schedules/services.py
@@ -10,8 +10,11 @@ from typing import Iterable, List
 from uuid import UUID
 
 from apps.schedules.models import Schedule
-from apps.schedules.schedules import create_schedule as create_schedule_model
-from apps.schedules.schedules import get_schedules_list
+from apps.schedules.schedules import (
+    create_schedule as create_schedule_model,
+    get_schedule_by_id as get_schedule_by_id_domain,
+    get_schedules_list,
+)
 from apps.schedules.schemas import ScheduleSchema
 
 
@@ -62,5 +65,9 @@ def get_schedule_schema_list(
 
 
 def get_schedule_schema_by_id(schedule_id: UUID) -> ScheduleSchema:
-    """Fetch schedule by id and return as ScheduleSchema."""
-    return ScheduleSchema.model_validate(Schedule.objects.get(pk=schedule_id))
+    """Fetch schedule by id and return as ScheduleSchema.
+
+    Delegates to apps.schedules.schedules.get_schedule_by_id.
+    """
+    schedule = get_schedule_by_id_domain(schedule_id)
+    return ScheduleSchema.model_validate(schedule)

--- a/apps/schedules/tests/test_views.py
+++ b/apps/schedules/tests/test_views.py
@@ -5,6 +5,7 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
+from apps.members.models import Member, Reservation
 from apps.schedules import constants
 from apps.schedules.models import Schedule
 
@@ -86,10 +87,12 @@ class TestScheduleViewSetRetrieve:
         assert "created" in data and "modified" in data
 
     @pytest.mark.django_db
-    def test_retrieve_not_found_returns_500(self, api_client):
-        api_client.raise_request_exception = False
+    def test_retrieve_not_found_returns_404(self, api_client):
         resp = api_client.get(reverse("schedule-detail", args=[uuid.uuid4()]))
-        assert resp.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+        data = resp.json()
+        assert "detail" in data
+        assert "Not found" in data["detail"]
 
 
 class TestScheduleViewSetCreate:
@@ -183,3 +186,62 @@ class TestScheduleViewSetCreate:
         }
         resp = api_client.post(reverse("schedule-list"), data=payload, format="json")
         assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+class TestScheduleViewSetReservations:
+    @pytest.mark.django_db
+    def test_reservations_list_success(self, api_client, schedules_sample):
+        """Test listing reservations for a specific schedule."""
+        from model_bakery import baker
+
+        schedule = schedules_sample[0]
+        # Create a member and reservations for this schedule
+        member = baker.make("members.Member")
+        reservation1 = Reservation.objects.create(member=member, schedule=schedule, spot=1)
+        reservation2 = Reservation.objects.create(member=member, schedule=schedule, spot=2)
+
+        # Create a reservation for a different schedule (should not appear)
+        other_schedule = schedules_sample[1]
+        Reservation.objects.create(member=member, schedule=other_schedule, spot=1)
+
+        # Call the reservations endpoint
+        url = reverse("schedule-reservations", args=[schedule.id])
+        resp = api_client.get(url)
+
+        assert resp.status_code == status.HTTP_200_OK
+        data = resp.json()
+        assert isinstance(data, list)
+        assert len(data) == 2
+
+        # Verify the reservations belong to the correct schedule
+        reservation_ids = {item["id"] for item in data}
+        assert reservation_ids == {str(reservation1.id), str(reservation2.id)}
+        for item in data:
+            assert item["schedule_id"] == str(schedule.id)
+            assert "member_id" in item
+            assert "status" in item
+            assert "spot" in item
+
+    @pytest.mark.django_db
+    def test_reservations_list_empty(self, api_client, schedules_sample):
+        """Test listing reservations for a schedule with no reservations."""
+        schedule = schedules_sample[0]
+
+        url = reverse("schedule-reservations", args=[schedule.id])
+        resp = api_client.get(url)
+
+        assert resp.status_code == status.HTTP_200_OK
+        data = resp.json()
+        assert isinstance(data, list)
+        assert len(data) == 0
+
+    @pytest.mark.django_db
+    def test_reservations_list_not_found(self, api_client):
+        """Test listing reservations for a non-existent schedule."""
+        url = reverse("schedule-reservations", args=[uuid.uuid4()])
+        resp = api_client.get(url)
+
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+        data = resp.json()
+        assert "detail" in data
+        assert "Not found" in data["detail"]

--- a/apps/schedules/urls.py
+++ b/apps/schedules/urls.py
@@ -4,7 +4,7 @@ from rest_framework.routers import DefaultRouter
 from apps.schedules.views import ScheduleViewSet
 
 router = DefaultRouter()
-router.register(r"schedules", ScheduleViewSet, basename="schedule")
+router.register(r"", ScheduleViewSet, basename="schedule")
 
 urlpatterns = [
     path("", include(router.urls)),

--- a/apps/schedules/views.py
+++ b/apps/schedules/views.py
@@ -1,10 +1,16 @@
 from rest_framework import status, viewsets
+from rest_framework.decorators import action
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 
+from apps.members.services import list_reservations
 from apps.schedules.models import Schedule
 from apps.schedules.serializers import ScheduleCreateSerializer, ScheduleSerializer
-from apps.schedules.services import create_schedule, get_schedule_schema_list
+from apps.schedules.services import (
+    create_schedule,
+    get_schedule_schema_by_id,
+    get_schedule_schema_list,
+)
 
 from django.utils.dateparse import parse_datetime
 
@@ -42,8 +48,15 @@ class ScheduleViewSet(viewsets.ViewSet):
         return Response(data)
 
     def retrieve(self, request, pk=None):
-        schedule = Schedule.objects.get(pk=pk)
-        data = ScheduleSerializer(schedule).data
+        try:
+            schedule_schema = get_schedule_schema_by_id(pk)
+        except Schedule.DoesNotExist:
+            return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
+        # Convert schema to dict and adjust field names to match serializer output
+        data = schedule_schema.model_dump()
+        # Map instructor_id -> instructor and room_id -> room to match serializer
+        data["instructor"] = str(data.pop("instructor_id"))
+        data["room"] = str(data.pop("room_id"))
         return Response(data)
 
     def create(self, request):
@@ -51,3 +64,16 @@ class ScheduleViewSet(viewsets.ViewSet):
         serializer.is_valid(raise_exception=True)
         schedule_schema = create_schedule(**serializer.validated_data)
         return Response(schedule_schema.model_dump(), status=status.HTTP_201_CREATED)
+
+    @action(detail=True, methods=["get"], url_path="reservations")
+    def reservations(self, request, pk=None):
+        """List reservations for a specific schedule."""
+        try:
+            schedule_schema = get_schedule_schema_by_id(pk)
+        except Schedule.DoesNotExist:
+            return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
+
+        # Use the list_reservations service with schedule_id filter
+        reservation_schemas = list_reservations({"schedule_id": str(schedule_schema.id)})
+        data = [schema.model_dump() for schema in reservation_schemas]
+        return Response(data, status=status.HTTP_200_OK)


### PR DESCRIPTION
Allows listing reservations by date range or by schedule ID.
Adds validation to ensure either schedule_id or both start_date and end_date are provided.
Updates service and domain layers to support filtering by schedule ID.
Fixes a 500 error when schedule is not found and changes it to a 404.
Adds an endpoint to list reservations for a given schedule.
