### PR TITLE
Adds reservation spot change functionality

### DIFF
--- a/apps/members/members.py
+++ b/apps/members/members.py
@@ -1,3 +1,4 @@
+from django.db import transaction
 from django.db.models import QuerySet
 
 from apps.members import constants
@@ -106,6 +107,69 @@ def cancel_reservation(reservation_id: str) -> Reservation:
     reservation.status = constants.RESERVATION_STATUS_CANCELLED
     reservation.save(update_fields=["status", "modified"])
     return reservation
+
+
+def change_reservation_spot(schedule_id: str, user_id: str, new_spot: int) -> Reservation:
+    """Change the spot of an existing reservation atomically.
+
+    This function:
+    1. Finds the reservation for the given schedule and user
+    2. Validates the reservation exists and is in RESERVED status
+    3. Validates the new spot is available and valid
+    4. Updates the spot in a single transaction
+
+    Raises:
+        Reservation.DoesNotExist: If reservation doesn't exist
+        ReservationInvalidStateException: If reservation is not RESERVED
+        InvalidSpotException: If new spot is invalid or unavailable
+    """
+    with transaction.atomic():
+        # Get member from user_id
+        member = get_member_by_user_id(user_id)
+
+        # Find the reservation for this schedule and member (without status filter first)
+        reservation = Reservation.objects.filter(
+            schedule_id=schedule_id,
+            member=member,
+        ).first()
+
+        if not reservation:
+            raise Reservation.DoesNotExist(
+                f"Reservation not found for schedule {schedule_id} and user {user_id}"
+            )
+
+        # Validate reservation is in RESERVED status
+        if reservation.status != constants.RESERVATION_STATUS_RESERVED:
+            raise ReservationInvalidStateException("Only RESERVED reservations can change spots.")
+
+        schedule = reservation.schedule
+        room_capacity = schedule.room.capacity
+
+        # Validate spot range
+        if new_spot < 1:
+            raise InvalidSpotException("Spot must be greater than or equal to 1.")
+        if new_spot > room_capacity:
+            raise InvalidSpotException(
+                f"Spot must be less than or equal to the room capacity ({room_capacity})."
+            )
+
+        # Check if new spot is already taken by another reservation
+        existing_reservation = (
+            Reservation.objects.filter(
+                schedule=schedule, spot=new_spot, status=constants.RESERVATION_STATUS_RESERVED
+            )
+            .exclude(id=reservation.id)
+            .first()
+        )
+
+        if existing_reservation:
+            raise InvalidSpotException(f"Spot {new_spot} is already taken.")
+
+        # Update the spot
+        reservation.spot = new_spot
+        reservation.save(update_fields=["spot", "modified"])
+
+        return reservation
 
 
 def list_reservations_by_date_range(

--- a/apps/members/serializers.py
+++ b/apps/members/serializers.py
@@ -63,3 +63,7 @@ class ReservationListQuerySerializer(serializers.Serializer):
             raise serializers.ValidationError("'start_date' must be before or equal to 'end_date'.")
 
         return attrs
+
+
+class ReservationChangeSpotSerializer(serializers.Serializer):
+    new_spot = serializers.IntegerField(min_value=1)

--- a/apps/members/services.py
+++ b/apps/members/services.py
@@ -36,6 +36,12 @@ def cancel_reservation(reservation_id: str) -> ReservationSchema:
     return ReservationSchema.model_validate(reservation)
 
 
+def change_reservation_spot(schedule_id: str, user_id: str, new_spot: int) -> ReservationSchema:
+    """Application service: change reservation spot and return ReservationSchema."""
+    reservation = members.change_reservation_spot(schedule_id, user_id, new_spot)
+    return ReservationSchema.model_validate(reservation)
+
+
 def list_reservations(validated_query: dict) -> list[ReservationSchema]:
     """Application service: list reservations via domain and return schemas."""
     # Map serializer field names to function parameter names

--- a/apps/members/tests/test_members.py
+++ b/apps/members/tests/test_members.py
@@ -5,8 +5,10 @@ import pytest
 from django.contrib.auth import get_user_model
 from django.utils import timezone
 
-from apps.members.members import list_reservations_by_date_range
+from apps.members import constants
+from apps.members.members import list_reservations_by_date_range, change_reservation_spot
 from apps.members.models import Member, Reservation
+from apps.members.exceptions import InvalidSpotException, ReservationInvalidStateException
 from apps.studios.models import Studio, Room
 from apps.instructors.models import Instructor
 from apps.schedules.models import Schedule
@@ -107,3 +109,156 @@ class TestMembersDomain:
             start_date=start_date, end_date=end_date, room_id=str(room_a.id)
         )
         assert {str(x.id) for x in qs_room} == {str(r1.id)}
+
+    def test_change_reservation_spot_success_updates_spot(self):
+        User = get_user_model()
+        user = User.objects.create_user(
+            username=f"member_{uuid.uuid4()}", email=f"m_{uuid.uuid4()}@ex.com", password="pass"
+        )
+        member = Member.objects.create(user=user)
+        user_instructor = User.objects.create_user(
+            username=f"instr_{uuid.uuid4()}", email=f"i_{uuid.uuid4()}@ex.com", password="pass"
+        )
+        instructor = Instructor.objects.create(user=user_instructor)
+        studio = Studio.objects.create(name="S1", address="Addr", is_active=True)
+        room = Room.objects.create(studio=studio, name="R1", capacity=10, is_active=True)
+        schedule = Schedule.objects.create(
+            instructor=instructor,
+            start_time=timezone.now() + datetime.timedelta(days=1),
+            duration_minutes=45,
+            room=room,
+        )
+        reservation = Reservation.objects.create(
+            member=member,
+            schedule=schedule,
+            status=constants.RESERVATION_STATUS_RESERVED,
+            spot=1,
+        )
+
+        updated_reservation = change_reservation_spot(str(schedule.id), str(user.id), 5)
+
+        assert updated_reservation.spot == 5
+        reservation.refresh_from_db()
+        assert reservation.spot == 5
+
+    def test_change_reservation_spot_not_found_raises_exception(self):
+        User = get_user_model()
+        user = User.objects.create_user(
+            username=f"member_{uuid.uuid4()}", email=f"m_{uuid.uuid4()}@ex.com", password="pass"
+        )
+        Member.objects.create(user=user)
+        user_instructor = User.objects.create_user(
+            username=f"instr_{uuid.uuid4()}", email=f"i_{uuid.uuid4()}@ex.com", password="pass"
+        )
+        instructor = Instructor.objects.create(user=user_instructor)
+        studio = Studio.objects.create(name="S1", address="Addr", is_active=True)
+        room = Room.objects.create(studio=studio, name="R1", capacity=10, is_active=True)
+        schedule = Schedule.objects.create(
+            instructor=instructor,
+            start_time=timezone.now() + datetime.timedelta(days=1),
+            duration_minutes=45,
+            room=room,
+        )
+
+        with pytest.raises(Reservation.DoesNotExist):
+            change_reservation_spot(str(schedule.id), str(user.id), 5)
+
+    def test_change_reservation_spot_invalid_state_raises_exception(self):
+        User = get_user_model()
+        user = User.objects.create_user(
+            username=f"member_{uuid.uuid4()}", email=f"m_{uuid.uuid4()}@ex.com", password="pass"
+        )
+        member = Member.objects.create(user=user)
+        user_instructor = User.objects.create_user(
+            username=f"instr_{uuid.uuid4()}", email=f"i_{uuid.uuid4()}@ex.com", password="pass"
+        )
+        instructor = Instructor.objects.create(user=user_instructor)
+        studio = Studio.objects.create(name="S1", address="Addr", is_active=True)
+        room = Room.objects.create(studio=studio, name="R1", capacity=10, is_active=True)
+        schedule = Schedule.objects.create(
+            instructor=instructor,
+            start_time=timezone.now() + datetime.timedelta(days=1),
+            duration_minutes=45,
+            room=room,
+        )
+        Reservation.objects.create(
+            member=member,
+            schedule=schedule,
+            status=constants.RESERVATION_STATUS_CANCELLED,
+            spot=1,
+        )
+
+        with pytest.raises(ReservationInvalidStateException):
+            change_reservation_spot(str(schedule.id), str(user.id), 5)
+
+    def test_change_reservation_spot_invalid_spot_range_raises_exception(self):
+        User = get_user_model()
+        user = User.objects.create_user(
+            username=f"member_{uuid.uuid4()}", email=f"m_{uuid.uuid4()}@ex.com", password="pass"
+        )
+        member = Member.objects.create(user=user)
+        user_instructor = User.objects.create_user(
+            username=f"instr_{uuid.uuid4()}", email=f"i_{uuid.uuid4()}@ex.com", password="pass"
+        )
+        instructor = Instructor.objects.create(user=user_instructor)
+        studio = Studio.objects.create(name="S1", address="Addr", is_active=True)
+        room = Room.objects.create(studio=studio, name="R1", capacity=10, is_active=True)
+        schedule = Schedule.objects.create(
+            instructor=instructor,
+            start_time=timezone.now() + datetime.timedelta(days=1),
+            duration_minutes=45,
+            room=room,
+        )
+        Reservation.objects.create(
+            member=member,
+            schedule=schedule,
+            status=constants.RESERVATION_STATUS_RESERVED,
+            spot=1,
+        )
+
+        # Test spot < 1
+        with pytest.raises(InvalidSpotException):
+            change_reservation_spot(str(schedule.id), str(user.id), 0)
+
+        # Test spot > capacity
+        with pytest.raises(InvalidSpotException):
+            change_reservation_spot(str(schedule.id), str(user.id), 11)
+
+    def test_change_reservation_spot_spot_already_taken_raises_exception(self):
+        User = get_user_model()
+        user1 = User.objects.create_user(
+            username=f"member1_{uuid.uuid4()}", email=f"m1_{uuid.uuid4()}@ex.com", password="pass"
+        )
+        user2 = User.objects.create_user(
+            username=f"member2_{uuid.uuid4()}", email=f"m2_{uuid.uuid4()}@ex.com", password="pass"
+        )
+        member1 = Member.objects.create(user=user1)
+        member2 = Member.objects.create(user=user2)
+        user_instructor = User.objects.create_user(
+            username=f"instr_{uuid.uuid4()}", email=f"i_{uuid.uuid4()}@ex.com", password="pass"
+        )
+        instructor = Instructor.objects.create(user=user_instructor)
+        studio = Studio.objects.create(name="S1", address="Addr", is_active=True)
+        room = Room.objects.create(studio=studio, name="R1", capacity=10, is_active=True)
+        schedule = Schedule.objects.create(
+            instructor=instructor,
+            start_time=timezone.now() + datetime.timedelta(days=1),
+            duration_minutes=45,
+            room=room,
+        )
+        Reservation.objects.create(
+            member=member1,
+            schedule=schedule,
+            status=constants.RESERVATION_STATUS_RESERVED,
+            spot=1,
+        )
+        Reservation.objects.create(
+            member=member2,
+            schedule=schedule,
+            status=constants.RESERVATION_STATUS_RESERVED,
+            spot=5,
+        )
+
+        # Try to change member1's spot to 5, which is already taken by member2
+        with pytest.raises(InvalidSpotException):
+            change_reservation_spot(str(schedule.id), str(user1.id), 5)

--- a/apps/members/tests/test_services.py
+++ b/apps/members/tests/test_services.py
@@ -3,9 +3,12 @@ import pytest
 
 from apps.members import constants
 from apps.members.models import Reservation, Member
-from apps.members.exceptions import ReservationInvalidStateException
-from apps.members.services import cancel_reservation as service_cancel_reservation
-from apps.members.services import list_reservations as service_list_reservations
+from apps.members.exceptions import ReservationInvalidStateException, InvalidSpotException
+from apps.members.services import (
+    cancel_reservation as service_cancel_reservation,
+    list_reservations as service_list_reservations,
+    change_reservation_spot as service_change_reservation_spot,
+)
 
 from django.contrib.auth import get_user_model
 from django.utils import timezone
@@ -225,3 +228,52 @@ class TestMembersServices:
         ids = {str(obj.id) for obj in result}
         assert ids == {str(r1.id)}
         assert str(result[0].schedule_id) == str(s1.id)
+
+    def test_change_reservation_spot_success_returns_schema_and_updates_db(self):
+        member, schedule = self._build_graph()
+        reservation = Reservation.objects.create(
+            member=member,
+            schedule=schedule,
+            status=constants.RESERVATION_STATUS_RESERVED,
+            spot=1,
+        )
+
+        schema = service_change_reservation_spot(str(schedule.id), str(member.user.id), 5)
+
+        # Returned object is a Pydantic ReservationSchema-like with attributes
+        assert str(schema.id) == str(reservation.id)
+        assert schema.spot == 5
+
+        # DB is updated
+        reservation.refresh_from_db()
+        assert reservation.spot == 5
+
+    def test_change_reservation_spot_not_found_bubbles_up(self):
+        member, schedule = self._build_graph()
+        with pytest.raises(Reservation.DoesNotExist):
+            service_change_reservation_spot(str(schedule.id), str(member.user.id), 5)
+
+    def test_change_reservation_spot_invalid_state_bubbles_custom_exception(self):
+        member, schedule = self._build_graph()
+        Reservation.objects.create(
+            member=member,
+            schedule=schedule,
+            status=constants.RESERVATION_STATUS_CANCELLED,
+            spot=1,
+        )
+
+        with pytest.raises(ReservationInvalidStateException):
+            service_change_reservation_spot(str(schedule.id), str(member.user.id), 5)
+
+    def test_change_reservation_spot_invalid_spot_bubbles_exception(self):
+        member, schedule = self._build_graph()
+        Reservation.objects.create(
+            member=member,
+            schedule=schedule,
+            status=constants.RESERVATION_STATUS_RESERVED,
+            spot=1,
+        )
+
+        # Test spot out of range
+        with pytest.raises(InvalidSpotException):
+            service_change_reservation_spot(str(schedule.id), str(member.user.id), 11)

--- a/apps/members/tests/test_views.py
+++ b/apps/members/tests/test_views.py
@@ -7,7 +7,7 @@ from django.urls import reverse
 from rest_framework.test import APIClient
 
 from apps.members.models import Reservation
-from apps.members.exceptions import ReservationInvalidStateException
+from apps.members.exceptions import ReservationInvalidStateException, InvalidSpotException
 from apps.members.schemas import MemberSchema, ReservationSchema
 from apps.users.schemas import UserSchema
 
@@ -457,5 +457,136 @@ class TestReservationsList:
                 # "end_date" is missing
             },
         )
+
+        assert resp.status_code == 400
+
+
+@pytest.mark.django_db
+class TestReservationChangeSpotViewSet:
+    @pytest.fixture
+    def api_client(self):
+        return APIClient()
+
+    def _make_reservation_schema_mock(
+        self, reservation_id: uuid.UUID, schedule_id: uuid.UUID, member_id: uuid.UUID, spot: int = 5
+    ):
+        class _ReservationSchemaLike:
+            def __init__(self):
+                self.id = reservation_id
+                self.schedule_id = schedule_id
+                self.member_id = member_id
+                self.status = "RESERVED"
+                self.spot = spot
+                self.notes = ""
+
+            def model_dump(self):
+                return {
+                    "id": self.id,
+                    "schedule_id": self.schedule_id,
+                    "member_id": self.member_id,
+                    "status": self.status,
+                    "spot": self.spot,
+                    "notes": self.notes,
+                }
+
+        return _ReservationSchemaLike()
+
+    def test_change_spot_returns_200_and_payload_forwarded(self, mocker, api_client):
+        user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="testpass123",
+        )
+        api_client.force_authenticate(user=user)
+        schedule_id = uuid.uuid4()
+        reservation_id = uuid.uuid4()
+        member_id = uuid.uuid4()
+        reservation_schema = self._make_reservation_schema_mock(
+            reservation_id, schedule_id, member_id, spot=5
+        )
+
+        change_spot_mock = mocker.patch(
+            "apps.members.views.change_reservation_spot", return_value=reservation_schema
+        )
+
+        url = reverse("reservation-change-spot", kwargs={"schedule_id": str(schedule_id)})
+        payload = {"new_spot": 5}
+        resp = api_client.patch(url, data=payload, format="json")
+
+        assert resp.status_code == 200
+        change_spot_mock.assert_called_once_with(schedule_id, str(user.id), 5)
+        assert str(resp.data["id"]) == str(reservation_id)
+        assert resp.data["spot"] == 5
+
+    def test_change_spot_returns_404_when_not_found(self, mocker, api_client):
+        user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="testpass123",
+        )
+        api_client.force_authenticate(user=user)
+        schedule_id = uuid.uuid4()
+        mocker.patch(
+            "apps.members.views.change_reservation_spot", side_effect=Reservation.DoesNotExist
+        )
+        url = reverse("reservation-change-spot", kwargs={"schedule_id": str(schedule_id)})
+        payload = {"new_spot": 5}
+        resp = api_client.patch(url, data=payload, format="json")
+
+        assert resp.status_code == 404
+        assert resp.data["detail"] == "Not found."
+
+    def test_change_spot_returns_400_when_invalid_state(self, mocker, api_client):
+        user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="testpass123",
+        )
+        api_client.force_authenticate(user=user)
+        schedule_id = uuid.uuid4()
+        mocker.patch(
+            "apps.members.views.change_reservation_spot",
+            side_effect=ReservationInvalidStateException(
+                "Only RESERVED reservations can change spots."
+            ),
+        )
+        url = reverse("reservation-change-spot", kwargs={"schedule_id": str(schedule_id)})
+        payload = {"new_spot": 5}
+        resp = api_client.patch(url, data=payload, format="json")
+
+        assert resp.status_code == 400
+        assert resp.data["detail"] == "Only RESERVED reservations can change spots."
+
+    def test_change_spot_returns_400_when_invalid_spot(self, mocker, api_client):
+        user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="testpass123",
+        )
+        api_client.force_authenticate(user=user)
+        schedule_id = uuid.uuid4()
+        mocker.patch(
+            "apps.members.views.change_reservation_spot",
+            side_effect=InvalidSpotException("Spot 5 is already taken."),
+        )
+        url = reverse("reservation-change-spot", kwargs={"schedule_id": str(schedule_id)})
+        payload = {"new_spot": 5}
+        resp = api_client.patch(url, data=payload, format="json")
+
+        assert resp.status_code == 400
+        assert resp.data["detail"] == "Spot 5 is already taken."
+
+    def test_change_spot_returns_400_when_invalid_serializer(self, api_client):
+        user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="testpass123",
+        )
+        api_client.force_authenticate(user=user)
+        schedule_id = uuid.uuid4()
+        url = reverse("reservation-change-spot", kwargs={"schedule_id": str(schedule_id)})
+        # Missing new_spot or invalid value
+        payload = {}
+        resp = api_client.patch(url, data=payload, format="json")
 
         assert resp.status_code == 400

--- a/apps/members/urls.py
+++ b/apps/members/urls.py
@@ -19,4 +19,9 @@ urlpatterns = [
         ReservationView.as_view({"post": "cancel"}),
         name="reservation-cancel",
     ),
+    path(
+        "reservations/<uuid:schedule_id>/change-spot/",
+        ReservationView.as_view({"patch": "change_spot"}),
+        name="reservation-change-spot",
+    ),
 ]

--- a/apps/members/views.py
+++ b/apps/members/views.py
@@ -12,12 +12,14 @@ from apps.members.serializers import (
     MemberSerializer,
     ReservationSerializer,
     ReservationListQuerySerializer,
+    ReservationChangeSpotSerializer,
 )
 from apps.members.services import (
     get_or_create_member_user,
     get_member_from_user_id,
     create_reservation,
     cancel_reservation,
+    change_reservation_spot,
     list_reservations,
 )
 from apps.members.models import Member, Reservation
@@ -82,5 +84,19 @@ class ReservationView(ViewSet):
         except Reservation.DoesNotExist:
             return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
         except ReservationInvalidStateException as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+        return Response(reservation.model_dump(), status=status.HTTP_200_OK)
+
+    def change_spot(self, request, schedule_id=None, *args, **kwargs):
+        serializer = ReservationChangeSpotSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        try:
+            reservation = change_reservation_spot(
+                schedule_id, str(request.user.id), serializer.validated_data["new_spot"]
+            )
+        except Reservation.DoesNotExist:
+            return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
+        except (ReservationInvalidStateException, InvalidSpotException) as exc:
             return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
         return Response(reservation.model_dump(), status=status.HTTP_200_OK)


### PR DESCRIPTION
Implements functionality to allow users to change the spot of their reservation.

This includes:
- Adding a new `change_reservation_spot` function to the members domain logic, performing validations and updating the reservation spot atomically.
- Creating a `ReservationChangeSpotSerializer` to validate the request data.
- Adding a `change_spot` action to the `ReservationView` to handle the API endpoint.
- Adding corresponding tests for the new functionality in both domain and services layers.
