### PR TITLE
Improves reservation status handling

### DIFF
--- a/apps/members/members.py
+++ b/apps/members/members.py
@@ -127,20 +127,31 @@ def change_reservation_spot(schedule_id: str, user_id: str, new_spot: int) -> Re
         # Get member from user_id
         member = get_member_by_user_id(user_id)
 
-        # Find the reservation for this schedule and member (without status filter first)
+        # Find the RESERVED reservation for this schedule and member
         reservation = Reservation.objects.filter(
             schedule_id=schedule_id,
             member=member,
+            status=constants.RESERVATION_STATUS_RESERVED,
         ).first()
 
+        # If no RESERVED reservation found, check if any reservation exists
+        # to provide a more specific error message
         if not reservation:
-            raise Reservation.DoesNotExist(
-                f"Reservation not found for schedule {schedule_id} and user {user_id}"
-            )
+            any_reservation = Reservation.objects.filter(
+                schedule_id=schedule_id,
+                member=member,
+            ).first()
 
-        # Validate reservation is in RESERVED status
-        if reservation.status != constants.RESERVATION_STATUS_RESERVED:
-            raise ReservationInvalidStateException("Only RESERVED reservations can change spots.")
+            if any_reservation:
+                # Reservation exists but is not RESERVED
+                raise ReservationInvalidStateException(
+                    "Only RESERVED reservations can change spots."
+                )
+            else:
+                # No reservation found at all
+                raise Reservation.DoesNotExist(
+                    f"Reservation not found for schedule {schedule_id} and user {user_id}"
+                )
 
         schedule = reservation.schedule
         room_capacity = schedule.room.capacity
@@ -186,6 +197,7 @@ def list_reservations_by_date_range(
 
     Uses __range for date filtering (inclusive) as requested.
     Can filter by schedule_id directly, or by date range with optional filters.
+    Excludes cancelled reservations from the results.
     """
     filters = {}
 
@@ -202,4 +214,8 @@ def list_reservations_by_date_range(
         filters["schedule__instructor_id"] = instructor_id
     if room_id is not None:
         filters["schedule__room_id"] = room_id
-    return Reservation.objects.filter(**filters)
+
+    # Exclude cancelled reservations
+    return Reservation.objects.filter(**filters).exclude(
+        status=constants.RESERVATION_STATUS_CANCELLED
+    )

--- a/apps/members/tests/test_members.py
+++ b/apps/members/tests/test_members.py
@@ -110,6 +110,38 @@ class TestMembersDomain:
         )
         assert {str(x.id) for x in qs_room} == {str(r1.id)}
 
+    def test_list_reservations_by_date_range_excludes_cancelled_reservations(self, base_graph):
+        member, instructor, room = base_graph
+
+        base = timezone.now().replace(hour=9, minute=0, second=0, microsecond=0)
+        s_today = Schedule.objects.create(
+            instructor=instructor,
+            start_time=base,
+            duration_minutes=60,
+            room=room,
+        )
+
+        r1 = Reservation.objects.create(
+            member=member, schedule=s_today, status=constants.RESERVATION_STATUS_RESERVED
+        )
+        r2 = Reservation.objects.create(
+            member=member, schedule=s_today, status=constants.RESERVATION_STATUS_CANCELLED
+        )
+        r3 = Reservation.objects.create(
+            member=member, schedule=s_today, status=constants.RESERVATION_STATUS_ATTENDED
+        )
+
+        start_date = base.date()
+        end_date = base.date()
+
+        qs = list_reservations_by_date_range(start_date=start_date, end_date=end_date)
+
+        ids = {str(x.id) for x in qs}
+        # Should include RESERVED and ATTENDED, but exclude CANCELLED
+        assert str(r1.id) in ids
+        assert str(r3.id) in ids
+        assert str(r2.id) not in ids
+
     def test_change_reservation_spot_success_updates_spot(self):
         User = get_user_model()
         user = User.objects.create_user(

--- a/apps/members/tests/test_services.py
+++ b/apps/members/tests/test_services.py
@@ -229,6 +229,49 @@ class TestMembersServices:
         assert ids == {str(r1.id)}
         assert str(result[0].schedule_id) == str(s1.id)
 
+    def test_list_reservations_excludes_cancelled_reservations(self):
+        User = get_user_model()
+        user_member = User.objects.create_user(
+            username=f"member_{uuid.uuid4()}", email=f"m_{uuid.uuid4()}@ex.com", password="pass"
+        )
+        member = Member.objects.create(user=user_member)
+        studio = Studio.objects.create(name="S5", address="Addr5", is_active=True)
+        room = Room.objects.create(studio=studio, name="R5", capacity=10, is_active=True)
+        instructor_user = User.objects.create_user(
+            username=f"instr_{uuid.uuid4()}", email=f"i5_{uuid.uuid4()}@ex.com", password="pass"
+        )
+        instructor = Instructor.objects.create(user=instructor_user)
+
+        base = timezone.now().replace(hour=9, minute=0, second=0, microsecond=0)
+        schedule = Schedule.objects.create(
+            instructor=instructor,
+            start_time=base,
+            duration_minutes=60,
+            room=room,
+        )
+
+        r1 = Reservation.objects.create(
+            member=member, schedule=schedule, status=constants.RESERVATION_STATUS_RESERVED
+        )
+        r2 = Reservation.objects.create(
+            member=member, schedule=schedule, status=constants.RESERVATION_STATUS_CANCELLED
+        )
+        r3 = Reservation.objects.create(
+            member=member, schedule=schedule, status=constants.RESERVATION_STATUS_ATTENDED
+        )
+
+        start_date = base.date()
+        end_date = base.date()
+
+        result = service_list_reservations({"start_date": start_date, "end_date": end_date})
+
+        assert isinstance(result, list)
+        ids = {str(obj.id) for obj in result}
+        # Should include RESERVED and ATTENDED, but exclude CANCELLED
+        assert str(r1.id) in ids
+        assert str(r3.id) in ids
+        assert str(r2.id) not in ids
+
     def test_change_reservation_spot_success_returns_schema_and_updates_db(self):
         member, schedule = self._build_graph()
         reservation = Reservation.objects.create(


### PR DESCRIPTION
Ensures only 'RESERVED' reservations can change spots and excludes 'CANCELLED' reservations from listing results.

This change addresses issues related to reservation status consistency when changing spots and listing reservations. It now explicitly checks for 'RESERVED' status before allowing spot changes. It also excludes 'CANCELLED' reservations from the 'list_reservations_by_date_range' method to provide a more accurate list of active reservations.
