### PR TITLE
Defaults reservation list to user's reservations

### DIFF
--- a/apps/members/tests/test_members.py
+++ b/apps/members/tests/test_members.py
@@ -6,9 +6,21 @@ from django.contrib.auth import get_user_model
 from django.utils import timezone
 
 from apps.members import constants
-from apps.members.members import list_reservations_by_date_range, change_reservation_spot
+from apps.members.members import (
+    list_reservations_by_date_range,
+    change_reservation_spot,
+    create_reservation,
+    cancel_reservation,
+    get_member_by_id,
+    get_member_by_user_id,
+    get_reservation_by_id,
+)
 from apps.members.models import Member, Reservation
-from apps.members.exceptions import InvalidSpotException, ReservationInvalidStateException
+from apps.members.exceptions import (
+    InvalidSpotException,
+    ReservationInvalidStateException,
+    RoomFullException,
+)
 from apps.studios.models import Studio, Room
 from apps.instructors.models import Instructor
 from apps.schedules.models import Schedule
@@ -109,6 +121,33 @@ class TestMembersDomain:
             start_date=start_date, end_date=end_date, room_id=str(room_a.id)
         )
         assert {str(x.id) for x in qs_room} == {str(r1.id)}
+
+    def test_list_reservations_by_date_range_filters_by_schedule_id(self, base_graph):
+        member, instructor, room = base_graph
+
+        base = timezone.now().replace(hour=9, minute=0, second=0, microsecond=0)
+        s1 = Schedule.objects.create(
+            instructor=instructor,
+            start_time=base,
+            duration_minutes=60,
+            room=room,
+        )
+        s2 = Schedule.objects.create(
+            instructor=instructor,
+            start_time=base + datetime.timedelta(days=1),
+            duration_minutes=60,
+            room=room,
+        )
+
+        r1 = Reservation.objects.create(member=member, schedule=s1)
+        r2 = Reservation.objects.create(member=member, schedule=s2)
+
+        # Filter by schedule_id directly (no date range needed)
+        qs = list_reservations_by_date_range(schedule_id=str(s1.id))
+
+        ids = {str(x.id) for x in qs}
+        assert ids == {str(r1.id)}
+        assert str(r2.id) not in ids
 
     def test_list_reservations_by_date_range_excludes_cancelled_reservations(self, base_graph):
         member, instructor, room = base_graph
@@ -294,3 +333,182 @@ class TestMembersDomain:
         # Try to change member1's spot to 5, which is already taken by member2
         with pytest.raises(InvalidSpotException):
             change_reservation_spot(str(schedule.id), str(user1.id), 5)
+
+    def test_create_reservation_success_creates_reservation(self, base_graph):
+        member, instructor, room = base_graph
+        schedule = Schedule.objects.create(
+            instructor=instructor,
+            start_time=timezone.now() + datetime.timedelta(days=1),
+            duration_minutes=45,
+            room=room,
+        )
+
+        validated_data = {
+            "user_id": member.user.id,
+            "schedule_id": schedule.id,
+            "spot": 1,
+            "notes": "Test notes",
+        }
+
+        reservation = create_reservation(validated_data)
+
+        assert reservation.member == member
+        assert reservation.schedule == schedule
+        assert reservation.spot == 1
+        assert reservation.notes == "Test notes"
+        assert reservation.status == constants.RESERVATION_STATUS_RESERVED
+
+    def test_create_reservation_creates_member_if_not_exists(self, mocker, base_graph):
+        _, instructor, room = base_graph
+        # Mock create_verification_code to avoid Celery connection issues
+        mocker.patch("apps.members.members.create_verification_code")
+        User = get_user_model()
+        user = User.objects.create_user(
+            username=f"newuser_{uuid.uuid4()}",
+            email=f"newuser_{uuid.uuid4()}@ex.com",
+            password="pass",
+        )
+        schedule = Schedule.objects.create(
+            instructor=instructor,
+            start_time=timezone.now() + datetime.timedelta(days=1),
+            duration_minutes=45,
+            room=room,
+        )
+
+        validated_data = {
+            "user_id": user.id,
+            "schedule_id": schedule.id,
+            "spot": 1,
+        }
+
+        reservation = create_reservation(validated_data)
+
+        # Member should be created
+        member = Member.objects.get(user=user)
+        assert reservation.member == member
+
+    def test_create_reservation_invalid_spot_less_than_one_raises_exception(self, base_graph):
+        member, instructor, room = base_graph
+        schedule = Schedule.objects.create(
+            instructor=instructor,
+            start_time=timezone.now() + datetime.timedelta(days=1),
+            duration_minutes=45,
+            room=room,
+        )
+
+        validated_data = {
+            "user_id": member.user.id,
+            "schedule_id": schedule.id,
+            "spot": 0,
+        }
+
+        with pytest.raises(InvalidSpotException):
+            create_reservation(validated_data)
+
+    def test_create_reservation_invalid_spot_greater_than_capacity_raises_exception(
+        self, base_graph
+    ):
+        member, instructor, room = base_graph
+        schedule = Schedule.objects.create(
+            instructor=instructor,
+            start_time=timezone.now() + datetime.timedelta(days=1),
+            duration_minutes=45,
+            room=room,
+        )
+
+        validated_data = {
+            "user_id": member.user.id,
+            "schedule_id": schedule.id,
+            "spot": room.capacity + 1,
+        }
+
+        with pytest.raises(InvalidSpotException):
+            create_reservation(validated_data)
+
+    def test_cancel_reservation_success_cancels_reservation(self, base_graph):
+        member, instructor, room = base_graph
+        schedule = Schedule.objects.create(
+            instructor=instructor,
+            start_time=timezone.now() + datetime.timedelta(days=1),
+            duration_minutes=45,
+            room=room,
+        )
+        reservation = Reservation.objects.create(
+            member=member,
+            schedule=schedule,
+            status=constants.RESERVATION_STATUS_RESERVED,
+            spot=1,
+        )
+
+        cancelled_reservation = cancel_reservation(str(reservation.id))
+
+        assert cancelled_reservation.status == constants.RESERVATION_STATUS_CANCELLED
+        reservation.refresh_from_db()
+        assert reservation.status == constants.RESERVATION_STATUS_CANCELLED
+
+    def test_cancel_reservation_not_found_raises_exception(self):
+        with pytest.raises(Reservation.DoesNotExist):
+            cancel_reservation(str(uuid.uuid4()))
+
+    def test_cancel_reservation_invalid_state_raises_exception(self, base_graph):
+        member, instructor, room = base_graph
+        schedule = Schedule.objects.create(
+            instructor=instructor,
+            start_time=timezone.now() + datetime.timedelta(days=1),
+            duration_minutes=45,
+            room=room,
+        )
+        reservation = Reservation.objects.create(
+            member=member,
+            schedule=schedule,
+            status=constants.RESERVATION_STATUS_CANCELLED,
+            spot=1,
+        )
+
+        with pytest.raises(ReservationInvalidStateException):
+            cancel_reservation(str(reservation.id))
+
+    def test_get_member_by_id_success(self, base_graph):
+        member, _, _ = base_graph
+        found_member = get_member_by_id(str(member.id))
+        assert found_member == member
+
+    def test_get_member_by_id_not_found_raises_exception(self):
+        with pytest.raises(Member.DoesNotExist):
+            get_member_by_id(str(uuid.uuid4()))
+
+    def test_get_member_by_user_id_success(self, base_graph):
+        member, _, _ = base_graph
+        found_member = get_member_by_user_id(str(member.user.id))
+        assert found_member == member
+
+    def test_get_member_by_user_id_not_found_raises_exception(self):
+        User = get_user_model()
+        user = User.objects.create_user(
+            username=f"nouser_{uuid.uuid4()}",
+            email=f"nouser_{uuid.uuid4()}@ex.com",
+            password="pass",
+        )
+        with pytest.raises(Member.DoesNotExist):
+            get_member_by_user_id(str(user.id))
+
+    def test_get_reservation_by_id_success(self, base_graph):
+        member, instructor, room = base_graph
+        schedule = Schedule.objects.create(
+            instructor=instructor,
+            start_time=timezone.now() + datetime.timedelta(days=1),
+            duration_minutes=45,
+            room=room,
+        )
+        reservation = Reservation.objects.create(
+            member=member,
+            schedule=schedule,
+            spot=1,
+        )
+
+        found_reservation = get_reservation_by_id(str(reservation.id))
+        assert found_reservation == reservation
+
+    def test_get_reservation_by_id_not_found_raises_exception(self):
+        with pytest.raises(Reservation.DoesNotExist):
+            get_reservation_by_id(str(uuid.uuid4()))

--- a/apps/members/tests/test_views.py
+++ b/apps/members/tests/test_views.py
@@ -388,11 +388,12 @@ class TestReservationsList:
             email="test@example.com",
             password="testpass123",
         )
+        # Create member for the user (required by the view)
+        member = Member.objects.create(user=user)
         api_client.force_authenticate(user=user)
         # Arrange
         start_date = datetime.date(2025, 1, 1)
         end_date = datetime.date(2025, 1, 31)
-        member_id = uuid.uuid4()
         instructor_id = uuid.uuid4()
         room_id = uuid.uuid4()
 
@@ -403,7 +404,7 @@ class TestReservationsList:
                 created=now,
                 modified=now,
                 schedule_id=uuid.uuid4(),
-                member_id=member_id,
+                member_id=member.id,
                 status="RESERVED",
                 spot=1,
                 notes="",
@@ -413,7 +414,7 @@ class TestReservationsList:
                 created=now,
                 modified=now,
                 schedule_id=uuid.uuid4(),
-                member_id=member_id,
+                member_id=member.id,
                 status="RESERVED",
                 spot=2,
                 notes="",
@@ -428,7 +429,6 @@ class TestReservationsList:
             data={
                 "start_date": start_date.isoformat(),
                 "end_date": end_date.isoformat(),
-                "member_id": str(member_id),
                 "schedule__instructor_id": str(instructor_id),
                 "schedule__room_id": str(room_id),
             },
@@ -439,7 +439,7 @@ class TestReservationsList:
         list_mock.assert_called_once()
         assert isinstance(resp.data, list)
         assert len(resp.data) == 2
-        assert str(resp.data[0]["member_id"]) == str(member_id)
+        assert str(resp.data[0]["member_id"]) == str(member.id)
         assert {"id", "schedule_id", "member_id", "status", "spot"}.issubset(resp.data[0].keys())
 
     def test_list_defaults_dates_and_member_when_not_provided(self, mocker, api_client):
@@ -478,14 +478,15 @@ class TestReservationsList:
             email="test@example.com",
             password="testpass123",
         )
+        Member.objects.create(user=user)
         api_client.force_authenticate(user=user)
-        # Missing required end_date
+        # Test invalid date range: start_date > end_date
         url = reverse("reservations")
         resp = api_client.get(
             url,
             data={
-                "start_date": datetime.date(2025, 1, 1).isoformat(),
-                # "end_date" is missing
+                "start_date": datetime.date(2025, 1, 31).isoformat(),
+                "end_date": datetime.date(2025, 1, 1).isoformat(),  # end_date before start_date
             },
         )
 

--- a/apps/members/tests/test_views.py
+++ b/apps/members/tests/test_views.py
@@ -6,7 +6,7 @@ from django.contrib.auth import get_user_model
 from django.urls import reverse
 from rest_framework.test import APIClient
 
-from apps.members.models import Reservation
+from apps.members.models import Reservation, Member
 from apps.members.exceptions import ReservationInvalidStateException, InvalidSpotException
 from apps.members.schemas import MemberSchema, ReservationSchema
 from apps.users.schemas import UserSchema
@@ -441,6 +441,36 @@ class TestReservationsList:
         assert len(resp.data) == 2
         assert str(resp.data[0]["member_id"]) == str(member_id)
         assert {"id", "schedule_id", "member_id", "status", "spot"}.issubset(resp.data[0].keys())
+
+    def test_list_defaults_dates_and_member_when_not_provided(self, mocker, api_client):
+        user = User.objects.create_user(
+            username="testuser-defaults",
+            email="test-defaults@example.com",
+            password="testpass123",
+        )
+        api_client.force_authenticate(user=user)
+
+        # Create a member linked to this user
+        member = Member.objects.create(user=user)
+
+        schemas = []
+        list_mock = mocker.patch("apps.members.views.list_reservations", return_value=schemas)
+
+        url = reverse("reservations")
+        resp = api_client.get(url)
+
+        assert resp.status_code == 200
+        assert resp.data == []
+        list_mock.assert_called_once()
+
+        # Ensure start_date, end_date and member_id were provided to the service
+        called_args, _ = list_mock.call_args
+        assert called_args
+        query = called_args[0]
+        assert "start_date" in query
+        assert "end_date" in query
+        assert "member_id" in query
+        assert str(query["member_id"]) == str(member.id)
 
     def test_list_returns_400_when_invalid_query(self, api_client):
         user = User.objects.create_user(

--- a/apps/members/views.py
+++ b/apps/members/views.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 from rest_framework import status
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
@@ -73,7 +75,26 @@ class ReservationView(ViewSet):
         return Response(reservation.model_dump(), status=status.HTTP_201_CREATED)
 
     def list(self, request, *args, **kwargs):
-        query_serializer = ReservationListQuerySerializer(data=request.query_params)
+        query_params = request.query_params
+        has_start_date = "start_date" in query_params
+        has_end_date = "end_date" in query_params
+        data = query_params.copy()
+
+        member = Member.objects.filter(user=request.user).first()
+        if not member:
+            return Response([], status=status.HTTP_200_OK)
+
+        data["member_id"] = str(member.id)
+
+        if not has_start_date:
+            today = date.today()
+            data["start_date"] = today.isoformat()
+
+        if not has_end_date:
+            # Use a far future date to effectively get all future reservations
+            data["end_date"] = date(2100, 1, 1).isoformat()
+
+        query_serializer = ReservationListQuerySerializer(data=data)
         query_serializer.is_valid(raise_exception=True)
         data = query_serializer.validated_data
         schemas = list_reservations(data)

--- a/apps/schedules/views.py
+++ b/apps/schedules/views.py
@@ -13,6 +13,7 @@ from apps.schedules.services import (
 )
 
 from django.utils.dateparse import parse_datetime
+from uuid import UUID
 
 
 class ScheduleViewSet(viewsets.ViewSet):
@@ -48,6 +49,15 @@ class ScheduleViewSet(viewsets.ViewSet):
         return Response(data)
 
     def retrieve(self, request, pk=None):
+        # Validate that pk is a valid UUID
+        try:
+            UUID(str(pk))
+        except (ValueError, TypeError):
+            return Response(
+                {"detail": f'"{pk}" is not a valid UUID.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
         try:
             schedule_schema = get_schedule_schema_by_id(pk)
         except Schedule.DoesNotExist:
@@ -68,6 +78,15 @@ class ScheduleViewSet(viewsets.ViewSet):
     @action(detail=True, methods=["get"], url_path="reservations")
     def reservations(self, request, pk=None):
         """List reservations for a specific schedule."""
+        # Validate that pk is a valid UUID
+        try:
+            UUID(str(pk))
+        except (ValueError, TypeError):
+            return Response(
+                {"detail": f'"{pk}" is not a valid UUID.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
         try:
             schedule_schema = get_schedule_schema_by_id(pk)
         except Schedule.DoesNotExist:


### PR DESCRIPTION
Ensures the reservation list view defaults to the currently
authenticated user's reservations when no member ID is provided
in the query parameters. It also defaults to a date range starting
from today until a far future date, if no start and end dates are
provided, respectively.

This provides a more intuitive user experience by automatically
filtering reservations to the user's own when they access the
reservation list without specifying any filtering criteria.
