### PR TITLE
Embeds full Address object in Studio schema

### DIFF
--- a/apps/studios/schemas.py
+++ b/apps/studios/schemas.py
@@ -33,8 +33,7 @@ class StudioSchema(BaseModel):
     created: datetime
     modified: datetime
     name: str
-    address: Optional[str] = None  # Address string from related Address object
-    address_id: Optional[uuid.UUID] = None
+    address: Optional[AddressSchema] = None  # Full Address object
     is_active: bool
     opening_time: Optional[time] = None
     closing_time: Optional[time] = None
@@ -52,16 +51,14 @@ class StudioSchema(BaseModel):
             # Handle ForeignKey fields
             if isinstance(field, models.ForeignKey):
                 if value:
-                    # Store the related object's address string and id
+                    # Store the related object as a nested schema
                     if field.name == "address":
-                        data["address"] = value.address
-                        data["address_id"] = value.id
+                        data["address"] = AddressSchema.model_validate(value)
                     else:
                         data[f"{field.name}_id"] = value.id
                 else:
                     if field.name == "address":
                         data["address"] = None
-                        data["address_id"] = None
                     else:
                         data[f"{field.name}_id"] = None
             else:

--- a/apps/studios/serializers.py
+++ b/apps/studios/serializers.py
@@ -3,11 +3,23 @@
 from rest_framework import serializers
 
 
+class AddressSerializer(serializers.Serializer):
+    id = serializers.UUIDField(read_only=True)
+    address = serializers.CharField(max_length=255)
+    latitude = serializers.DecimalField(
+        max_digits=9, decimal_places=6, required=False, allow_null=True
+    )
+    longitude = serializers.DecimalField(
+        max_digits=9, decimal_places=6, required=False, allow_null=True
+    )
+    created = serializers.DateTimeField(read_only=True)
+    modified = serializers.DateTimeField(read_only=True)
+
+
 class StudioSerializer(serializers.Serializer):
     id = serializers.UUIDField(read_only=True)
     name = serializers.CharField(max_length=100)
-    address = serializers.CharField(max_length=255, required=False, allow_null=True)
-    address_id = serializers.UUIDField(read_only=True, required=False, allow_null=True)
+    address = AddressSerializer(required=False, allow_null=True)
     is_active = serializers.BooleanField(required=False, default=False)
     opening_time = serializers.TimeField(required=False, allow_null=True)
     closing_time = serializers.TimeField(required=False, allow_null=True)
@@ -17,19 +29,16 @@ class StudioSerializer(serializers.Serializer):
     def to_representation(self, instance):
         """Override to handle address ForeignKey."""
         ret = super().to_representation(instance)
-        # Handle address ForeignKey - check if it's an Address instance or already a string
+        # Handle address ForeignKey - include full Address object
         if instance.address:
             if hasattr(instance.address, "address"):
-                # It's an Address instance
-                ret["address"] = instance.address.address
-                ret["address_id"] = str(instance.address.id)
+                # It's an Address instance - serialize it
+                ret["address"] = AddressSerializer(instance.address).data
             else:
                 # It's already a string (backward compatibility)
-                ret["address"] = str(instance.address)
-                ret["address_id"] = None
+                ret["address"] = None
         else:
             ret["address"] = None
-            ret["address_id"] = None
         return ret
 
 

--- a/apps/studios/tests/test_services.py
+++ b/apps/studios/tests/test_services.py
@@ -6,7 +6,7 @@ import pytest
 from django.http import Http404
 
 from apps.studios.models import Room, Studio
-from apps.studios.schemas import RoomSchema, StudioSchema
+from apps.studios.schemas import AddressSchema, RoomSchema, StudioSchema
 from apps.studios.services import get_list_rooms, get_list_studios, get_room, get_studio
 
 
@@ -19,8 +19,12 @@ class TestGetStudio:
         assert isinstance(result, StudioSchema)
         assert result.id == studio.id
         assert result.name == studio.name
-        assert result.address == studio.address.address
-        assert result.address_id == studio.address.id
+        # Address should be an AddressSchema object
+        assert isinstance(result.address, AddressSchema)
+        assert result.address.id == studio.address.id
+        assert result.address.address == studio.address.address
+        assert result.address.latitude == studio.address.latitude
+        assert result.address.longitude == studio.address.longitude
         # Should include rooms via rooms_list alias
         assert isinstance(result.rooms, list)
         assert len(result.rooms) == 1

--- a/apps/studios/tests/test_views.py
+++ b/apps/studios/tests/test_views.py
@@ -24,6 +24,11 @@ class TestStudioViewSet:
         assert set(["id", "name", "address", "is_active", "created", "modified"]).issubset(
             sample.keys()
         )
+        # Address should be an object (or null)
+        assert sample["address"] is None or isinstance(sample["address"], dict)
+        if sample["address"]:
+            assert "id" in sample["address"]
+            assert "address" in sample["address"]
         assert "rooms" not in sample
 
     @pytest.mark.django_db
@@ -33,6 +38,13 @@ class TestStudioViewSet:
         data = resp.json()
         assert data["id"] == str(studio.id)
         assert data["name"] == studio.name
+        # Address should be an object with full Address details
+        assert "address" in data
+        if data["address"]:
+            assert isinstance(data["address"], dict)
+            assert "id" in data["address"]
+            assert "address" in data["address"]
+            assert data["address"]["address"] == studio.address.address
         assert "rooms" not in data  # StudioSerializer does not expose rooms
 
     @pytest.mark.django_db


### PR DESCRIPTION
Updates the Studio schema and serializer to include the full Address object instead of just the address string and ID.

This change simplifies data handling and provides more complete address information when retrieving studio data.
