### PR TITLE
feat(schedules): add staff admin CRUD for class times

### DIFF
--- a/apps/schedules/schedules.py
+++ b/apps/schedules/schedules.py
@@ -46,6 +46,8 @@ def create_schedule(
     duration_minutes: int,
     room_id: UUID,
     status: str,
+    title: str = "",
+    description: str | None = None,
 ) -> Schedule:
     """Create and return a Schedule model instance.
 
@@ -65,6 +67,8 @@ def create_schedule(
     _ = get_room_by_id(room_id)
 
     schedule = Schedule.objects.create(
+        title=title or "",
+        description=description,
         instructor_id=instructor_id,
         start_time=start_time,
         duration_minutes=duration_minutes,
@@ -73,3 +77,38 @@ def create_schedule(
     )
 
     return schedule
+
+
+def update_schedule(schedule: Schedule, *, data: dict) -> Schedule:
+    """Apply staff-editable fields onto an existing schedule."""
+    if "status" in data and data["status"] not in constants.SCHEDULE_STATUSES:
+        raise ValueError("Invalid schedule status.")
+    if "duration_minutes" in data and data["duration_minutes"] is not None:
+        if int(data["duration_minutes"]) <= 0:
+            raise ValueError("duration_minutes must be a positive integer.")
+
+    dirty: list[str] = []
+
+    if "instructor_id" in data and data["instructor_id"] is not None:
+        get_instructor_by_id(data["instructor_id"])
+        schedule.instructor_id = data["instructor_id"]
+        dirty.append("instructor_id")
+
+    if "room_id" in data and data["room_id"] is not None:
+        get_room_by_id(data["room_id"])
+        schedule.room_id = data["room_id"]
+        dirty.append("room_id")
+
+    for field in ("title", "description", "start_time", "duration_minutes", "status"):
+        if field in data:
+            setattr(schedule, field, data[field])
+            dirty.append(field)
+
+    if dirty:
+        schedule.save(update_fields=[*dirty, "modified"])
+    return schedule
+
+
+def delete_schedule(schedule: Schedule) -> None:
+    """Soft-delete a schedule."""
+    schedule.delete()

--- a/apps/schedules/schemas.py
+++ b/apps/schedules/schemas.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class ScheduleSchema(BaseModel):
@@ -17,3 +17,40 @@ class ScheduleSchema(BaseModel):
     status: str
 
     model_config = {"from_attributes": True}
+
+
+class AdminScheduleSchema(BaseModel):
+    """Schedule row for the PulseFit staff admin calendar."""
+
+    id: uuid.UUID
+    title: str = ""
+    description: str | None = None
+    created: datetime
+    modified: datetime
+    instructor_id: uuid.UUID
+    instructor_name: str = ""
+    start_time: datetime
+    duration_minutes: int
+    room_id: uuid.UUID
+    room_name: str = ""
+    studio_id: uuid.UUID | None = None
+    studio_name: str | None = None
+    room_capacity: int | None = None
+    reservation_count: int = 0
+    status: str
+    copies_created: int | None = None
+
+    model_config = {"from_attributes": True}
+
+
+class AdminScheduleWriteSchema(BaseModel):
+    """Create or update payload for a class schedule from the staff admin."""
+
+    title: str | None = None
+    description: str | None = None
+    instructor_id: uuid.UUID | None = None
+    start_time: datetime | None = None
+    duration_minutes: int | None = None
+    room_id: uuid.UUID | None = None
+    status: str | None = None
+    repeat_weeks: int | None = Field(default=None, ge=1, le=16)

--- a/apps/schedules/services.py
+++ b/apps/schedules/services.py
@@ -5,17 +5,24 @@ Provide schema-based service functions that delegate to domain logic in schedule
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Iterable, List
 from uuid import UUID
 
+from django.db.models import Count, Q
+from django.shortcuts import get_object_or_404
+
+from apps.members import constants as member_constants
+from apps.schedules import constants
 from apps.schedules.models import Schedule
 from apps.schedules.schedules import (
     create_schedule as create_schedule_model,
+    delete_schedule as delete_schedule_model,
     get_schedule_by_id as get_schedule_by_id_domain,
     get_schedules_list,
+    update_schedule as update_schedule_model,
 )
-from apps.schedules.schemas import ScheduleSchema
+from apps.schedules.schemas import AdminScheduleSchema, ScheduleSchema
 
 
 def create_schedule(
@@ -25,6 +32,8 @@ def create_schedule(
     duration_minutes: int,
     room_id: UUID,
     status: str,
+    title: str = "",
+    description: str | None = None,
 ) -> ScheduleSchema:
     """Create a schedule and return a ScheduleSchema.
 
@@ -36,6 +45,8 @@ def create_schedule(
         duration_minutes=duration_minutes,
         room_id=room_id,
         status=status,
+        title=title,
+        description=description,
     )
     return ScheduleSchema.model_validate(schedule)
 
@@ -71,3 +82,182 @@ def get_schedule_schema_by_id(schedule_id: UUID) -> ScheduleSchema:
     """
     schedule = get_schedule_by_id_domain(schedule_id)
     return ScheduleSchema.model_validate(schedule)
+
+
+def _instructor_display_name(schedule: Schedule) -> str:
+    user = getattr(schedule.instructor, "user", None)
+    if not user:
+        return ""
+    name = " ".join(part for part in [user.first_name, user.last_name] if part).strip()
+    return name or user.username or user.email or ""
+
+
+def _serialize_admin_schedule(schedule: Schedule, *, copies_created: int | None = None) -> dict:
+    room = schedule.room
+    studio = getattr(room, "studio", None)
+    payload = {
+        "id": schedule.id,
+        "title": schedule.title or "",
+        "description": schedule.description,
+        "created": schedule.created,
+        "modified": schedule.modified,
+        "instructor_id": schedule.instructor_id,
+        "instructor_name": _instructor_display_name(schedule),
+        "start_time": schedule.start_time,
+        "duration_minutes": schedule.duration_minutes,
+        "room_id": schedule.room_id,
+        "room_name": room.name if room else "",
+        "studio_id": studio.id if studio else None,
+        "studio_name": studio.name if studio else None,
+        "room_capacity": room.capacity if room else None,
+        "reservation_count": (
+            getattr(schedule, "reservation_count", None)
+            if getattr(schedule, "reservation_count", None) is not None
+            else schedule.reservations.filter(
+                is_removed=False,
+                status=member_constants.RESERVATION_STATUS_RESERVED,
+            ).count()
+        ),
+        "status": schedule.status,
+        "copies_created": copies_created,
+    }
+    return AdminScheduleSchema.model_validate(payload).model_dump(mode="json")
+
+
+def _admin_queryset():
+    return (
+        Schedule.objects.select_related("instructor__user", "room__studio")
+        .annotate(
+            reservation_count=Count(
+                "reservations",
+                filter=Q(
+                    reservations__is_removed=False,
+                    reservations__status=member_constants.RESERVATION_STATUS_RESERVED,
+                ),
+            )
+        )
+        .order_by("start_time")
+    )
+
+
+def list_admin_schedules(
+    *,
+    search: str | None = None,
+    status: str | None = None,
+    instructor_id: str | UUID | None = None,
+    room_id: str | UUID | None = None,
+    start_time: datetime | None = None,
+    end_time: datetime | None = None,
+) -> list[dict]:
+    """Return non-deleted schedules for the staff admin calendar."""
+    queryset = _admin_queryset()
+
+    if status in constants.SCHEDULE_STATUSES:
+        queryset = queryset.filter(status=status)
+    if instructor_id:
+        queryset = queryset.filter(instructor_id=instructor_id)
+    if room_id:
+        queryset = queryset.filter(room_id=room_id)
+    if start_time is not None:
+        queryset = queryset.filter(start_time__gte=start_time)
+    if end_time is not None:
+        queryset = queryset.filter(start_time__lte=end_time)
+
+    term = (search or "").strip()
+    if term:
+        queryset = queryset.filter(
+            Q(title__icontains=term)
+            | Q(description__icontains=term)
+            | Q(room__name__icontains=term)
+            | Q(room__studio__name__icontains=term)
+            | Q(instructor__user__first_name__icontains=term)
+            | Q(instructor__user__last_name__icontains=term)
+            | Q(instructor__user__username__icontains=term)
+        ).distinct()
+
+    return [_serialize_admin_schedule(schedule) for schedule in queryset]
+
+
+def get_admin_schedule(*, schedule_id: str | UUID) -> dict:
+    schedule = get_object_or_404(_admin_queryset(), id=schedule_id)
+    return _serialize_admin_schedule(schedule)
+
+
+def _validate_schedule_write(*, data: dict, require_required_fields: bool) -> None:
+    if require_required_fields:
+        if not data.get("instructor_id"):
+            raise ValueError("El instructor es obligatorio.")
+        if not data.get("room_id"):
+            raise ValueError("La sala es obligatoria.")
+        if data.get("start_time") is None:
+            raise ValueError("La fecha y hora de inicio son obligatorias.")
+        if data.get("duration_minutes") is None:
+            raise ValueError("La duración es obligatoria.")
+
+    if "title" in data and data["title"] is not None and not str(data["title"]).strip():
+        raise ValueError("El título no puede estar vacío.")
+
+    if "duration_minutes" in data and data["duration_minutes"] is not None:
+        if int(data["duration_minutes"]) <= 0:
+            raise ValueError("La duración debe ser un número positivo.")
+
+    if (
+        "status" in data
+        and data["status"] is not None
+        and data["status"] not in constants.SCHEDULE_STATUSES
+    ):
+        raise ValueError("El estado de la clase es inválido.")
+
+    if "repeat_weeks" in data and data["repeat_weeks"] is not None:
+        weeks = int(data["repeat_weeks"])
+        if weeks < 1 or weeks > 16:
+            raise ValueError("repeat_weeks debe estar entre 1 y 16.")
+
+
+def create_admin_schedule(*, data: dict) -> dict:
+    """Create one class, optionally repeating it weekly."""
+    _validate_schedule_write(data=data, require_required_fields=True)
+
+    title = str(data.get("title") or "").strip()
+    weeks = int(data.get("repeat_weeks") or 1)
+    created: list[Schedule] = []
+    start_time = data["start_time"]
+
+    for offset in range(weeks):
+        schedule = create_schedule_model(
+            instructor_id=data["instructor_id"],
+            start_time=start_time + timedelta(weeks=offset),
+            duration_minutes=int(data["duration_minutes"]),
+            room_id=data["room_id"],
+            status=data.get("status") or constants.SCHEDULE_STATUS_SCHEDULED,
+            title=title,
+            description=data.get("description"),
+        )
+        created.append(schedule)
+
+    first = get_object_or_404(_admin_queryset(), id=created[0].id)
+    return _serialize_admin_schedule(first, copies_created=len(created))
+
+
+def update_admin_schedule(*, schedule_id: str | UUID, data: dict) -> dict:
+    _validate_schedule_write(data=data, require_required_fields=False)
+    if "repeat_weeks" in data:
+        data = {key: value for key, value in data.items() if key != "repeat_weeks"}
+
+    schedule = get_object_or_404(Schedule, id=schedule_id)
+    if "title" in data and data["title"] is not None:
+        data["title"] = str(data["title"]).strip()
+
+    update_schedule_model(schedule, data=data)
+    return get_admin_schedule(schedule_id=schedule.id)
+
+
+def delete_admin_schedule(*, schedule_id: str | UUID) -> None:
+    schedule = get_object_or_404(_admin_queryset(), id=schedule_id)
+    reserved = int(getattr(schedule, "reservation_count", 0) or 0)
+    if reserved > 0:
+        raise ValueError(
+            "No se puede eliminar una clase con reservas activas. "
+            "Cáncela la clase o reubica a los socios primero."
+        )
+    delete_schedule_model(schedule)

--- a/apps/schedules/tests/test_admin_views.py
+++ b/apps/schedules/tests/test_admin_views.py
@@ -1,0 +1,136 @@
+"""API tests for staff admin schedule endpoints."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from drf_expiring_token.models import ExpiringToken
+from rest_framework import status
+
+from apps.members import constants as member_constants
+from apps.members.models import Member, Reservation
+from apps.schedules import constants
+from apps.schedules.models import Schedule
+
+User = get_user_model()
+
+
+@pytest.fixture
+def staff_user():
+    return User.objects.create_user(
+        username="scheduleadmin",
+        email="scheduleadmin@example.com",
+        password="pass1234",
+        is_staff=True,
+    )
+
+
+@pytest.fixture
+def staff_client(api_client, staff_user):
+    token = ExpiringToken.objects.create(user=staff_user)
+    api_client.credentials(HTTP_AUTHORIZATION=f"Token {token.key}")
+    return api_client
+
+
+@pytest.mark.django_db
+class TestAdminScheduleViews:
+    def test_list_requires_staff(self, api_client, schedules_sample):
+        user = User.objects.create_user(
+            username="member",
+            email="member@example.com",
+            password="pass1234",
+        )
+        token = ExpiringToken.objects.create(user=user)
+        api_client.credentials(HTTP_AUTHORIZATION=f"Token {token.key}")
+
+        response = api_client.get(reverse("admin-schedule-list"))
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_list_returns_nested_labels(self, staff_client, schedules_sample):
+        response = staff_client.get(reverse("admin-schedule-list"))
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 3
+        row = response.data[0]
+        assert row["instructor_name"]
+        assert row["room_name"]
+        assert "reservation_count" in row
+
+    def test_list_filters_by_range_and_status(self, staff_client, schedules_sample):
+        sample = schedules_sample[0]
+        sample.status = constants.SCHEDULE_STATUS_DRAFT
+        sample.save(update_fields=["status"])
+
+        start = sample.start_time.isoformat().replace("+00:00", "Z")
+        end = (sample.start_time + timedelta(minutes=1)).isoformat().replace("+00:00", "Z")
+        response = staff_client.get(
+            reverse("admin-schedule-list"),
+            {
+                "start_time": start,
+                "end_time": end,
+                "status": constants.SCHEDULE_STATUS_DRAFT,
+            },
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert [row["id"] for row in response.data] == [str(sample.id)]
+
+    def test_create_repeat_weeks_and_update_and_delete(
+        self, staff_client, instructor_alice, room_main
+    ):
+        create_response = staff_client.post(
+            reverse("admin-schedule-list"),
+            data={
+                "title": "RIDE 45",
+                "description": "Full body",
+                "instructor_id": str(instructor_alice.id),
+                "room_id": str(room_main.id),
+                "start_time": datetime(2026, 8, 24, 7, 0, tzinfo=timezone.utc)
+                .isoformat()
+                .replace("+00:00", "Z"),
+                "duration_minutes": 45,
+                "status": constants.SCHEDULE_STATUS_SCHEDULED,
+                "repeat_weeks": 3,
+            },
+            format="json",
+        )
+        assert create_response.status_code == status.HTTP_201_CREATED
+        assert create_response.data["title"] == "RIDE 45"
+        assert create_response.data["copies_created"] == 3
+        assert Schedule.objects.filter(title="RIDE 45").count() == 3
+
+        schedule_id = create_response.data["id"]
+        update_response = staff_client.patch(
+            reverse("admin-schedule-detail", kwargs={"schedule_id": schedule_id}),
+            data={"title": "RIDE 60", "duration_minutes": 60},
+            format="json",
+        )
+        assert update_response.status_code == status.HTTP_200_OK
+        assert update_response.data["title"] == "RIDE 60"
+        assert update_response.data["duration_minutes"] == 60
+
+        delete_response = staff_client.delete(
+            reverse("admin-schedule-detail", kwargs={"schedule_id": schedule_id})
+        )
+        assert delete_response.status_code == status.HTTP_204_NO_CONTENT
+        assert Schedule.objects.filter(id=schedule_id).count() == 0
+
+    def test_delete_blocked_when_reservations_exist(self, staff_client, schedules_sample):
+        schedule = schedules_sample[0]
+        member_user = User.objects.create_user(
+            username="rider",
+            email="rider@example.com",
+            password="pass1234",
+        )
+        member = Member.objects.create(user=member_user)
+        Reservation.objects.create(
+            member=member,
+            schedule=schedule,
+            status=member_constants.RESERVATION_STATUS_RESERVED,
+        )
+
+        response = staff_client.delete(
+            reverse("admin-schedule-detail", kwargs={"schedule_id": schedule.id})
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "reservas activas" in response.data["detail"]
+        assert Schedule.objects.filter(id=schedule.id).exists()

--- a/apps/schedules/urls.py
+++ b/apps/schedules/urls.py
@@ -1,11 +1,21 @@
 from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
-from apps.schedules.views import ScheduleViewSet
+from apps.schedules.views import (
+    AdminScheduleDetailView,
+    AdminScheduleListView,
+    ScheduleViewSet,
+)
 
 router = DefaultRouter()
 router.register(r"", ScheduleViewSet, basename="schedule")
 
 urlpatterns = [
+    path("admin/schedules/", AdminScheduleListView.as_view(), name="admin-schedule-list"),
+    path(
+        "admin/schedules/<uuid:schedule_id>/",
+        AdminScheduleDetailView.as_view(),
+        name="admin-schedule-detail",
+    ),
     path("", include(router.urls)),
 ]

--- a/apps/schedules/views.py
+++ b/apps/schedules/views.py
@@ -1,19 +1,50 @@
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
-from rest_framework.permissions import AllowAny
+from rest_framework.permissions import AllowAny, IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
 
 from apps.members.services import list_reservations
 from apps.schedules.models import Schedule
-from apps.schedules.serializers import ScheduleCreateSerializer, ScheduleSerializer
+from apps.schedules.serializers import ScheduleCreateSerializer
 from apps.schedules.services import (
+    create_admin_schedule,
     create_schedule,
+    delete_admin_schedule,
+    get_admin_schedule,
     get_schedule_schema_by_id,
     get_schedule_schema_list,
+    list_admin_schedules,
+    update_admin_schedule,
 )
 
 from django.utils.dateparse import parse_datetime
 from uuid import UUID
+
+from pydantic import ValidationError as PydanticValidationError
+from rest_framework.views import APIView
+
+from apps.schedules.schemas import AdminScheduleWriteSchema
+
+
+def _pydantic_error_response(exc: PydanticValidationError) -> Response:
+    first = exc.errors()[0] if exc.errors() else {}
+    loc = ".".join(str(part) for part in first.get("loc", [])) or "payload"
+    return Response(
+        {"detail": f"{loc}: {first.get('msg', 'Datos inválidos.')}"},
+        status=status.HTTP_400_BAD_REQUEST,
+    )
+
+
+def _parse_datetime_param(value: str | None, field_name: str):
+    if not value:
+        return None
+    parsed = parse_datetime(value)
+    if parsed is None:
+        return Response(
+            {"detail": (f"Invalid {field_name} format. Use ISO 8601, e.g. 2025-10-03T13:57:00Z.")},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+    return parsed
 
 
 class ScheduleViewSet(viewsets.ViewSet):
@@ -22,16 +53,10 @@ class ScheduleViewSet(viewsets.ViewSet):
     permission_classes = [AllowAny]
 
     def _get_start_time_params(self, start_time: str | None = None):
-        if start_time:
-            start_time = parse_datetime(start_time)
-            if start_time is None:
-                return Response(
-                    {
-                        "detail": "Invalid start_time format. Use ISO 8601, e.g. 2025-10-03T13:57:00Z."
-                    },
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
-        return start_time
+        parsed = _parse_datetime_param(start_time, "start_time")
+        if isinstance(parsed, Response):
+            return parsed
+        return parsed
 
     def list(self, request):
         start_time_str = request.query_params.get("start_time")
@@ -96,3 +121,70 @@ class ScheduleViewSet(viewsets.ViewSet):
         reservation_schemas = list_reservations({"schedule_id": str(schedule_schema.id)})
         data = [schema.model_dump() for schema in reservation_schemas]
         return Response(data, status=status.HTTP_200_OK)
+
+
+class AdminScheduleListView(APIView):
+    """List or create class schedules for the PulseFit admin. Staff only."""
+
+    permission_classes = [IsAuthenticated, IsAdminUser]
+
+    def get(self, request, *args, **kwargs):
+        start_time = _parse_datetime_param(request.query_params.get("start_time"), "start_time")
+        if isinstance(start_time, Response):
+            return start_time
+        end_time = _parse_datetime_param(request.query_params.get("end_time"), "end_time")
+        if isinstance(end_time, Response):
+            return end_time
+
+        schedules = list_admin_schedules(
+            search=request.query_params.get("search"),
+            status=request.query_params.get("status"),
+            instructor_id=request.query_params.get("instructor_id"),
+            room_id=request.query_params.get("room_id"),
+            start_time=start_time,
+            end_time=end_time,
+        )
+        return Response(schedules, status=status.HTTP_200_OK)
+
+    def post(self, request, *args, **kwargs):
+        try:
+            payload = AdminScheduleWriteSchema.model_validate(request.data)
+        except PydanticValidationError as exc:
+            return _pydantic_error_response(exc)
+
+        try:
+            schedule = create_admin_schedule(data=payload.model_dump(exclude_unset=True))
+        except ValueError as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+        return Response(schedule, status=status.HTTP_201_CREATED)
+
+
+class AdminScheduleDetailView(APIView):
+    """Retrieve, update, or delete a class schedule. Staff only."""
+
+    permission_classes = [IsAuthenticated, IsAdminUser]
+
+    def get(self, request, schedule_id, *args, **kwargs):
+        return Response(get_admin_schedule(schedule_id=schedule_id), status=status.HTTP_200_OK)
+
+    def patch(self, request, schedule_id, *args, **kwargs):
+        try:
+            payload = AdminScheduleWriteSchema.model_validate(request.data)
+        except PydanticValidationError as exc:
+            return _pydantic_error_response(exc)
+
+        try:
+            schedule = update_admin_schedule(
+                schedule_id=schedule_id,
+                data=payload.model_dump(exclude_unset=True),
+            )
+        except ValueError as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+        return Response(schedule, status=status.HTTP_200_OK)
+
+    def delete(self, request, schedule_id, *args, **kwargs):
+        try:
+            delete_admin_schedule(schedule_id=schedule_id)
+        except ValueError as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+        return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
## Motivation
The PulseFit admin needs authenticated APIs to manage class schedules instead of relying on the public ViewSet or Django admin.

## Implementation
- `GET/POST /api/schedules/admin/schedules/` (staff only)
- `GET/PATCH/DELETE /api/schedules/admin/schedules/{id}/`
- Nested instructor/room/studio labels and active reservation counts
- Optional `repeat_weeks` (1–16) on create
- Soft-delete blocked while a class has active reservations

## Test Plan
```bash
python -m pytest apps/schedules/tests/test_admin_views.py apps/schedules/tests/test_services.py apps/schedules/tests/test_views.py -q
```

## Rollback
Revert this PR. Public schedule list/retrieve/create endpoints are unchanged.

Made with [Cursor](https://cursor.com)