### PR TITLE
feat(members): add staff admin CRUD for socios

### DIFF
--- a/apps/members/schemas.py
+++ b/apps/members/schemas.py
@@ -1,7 +1,8 @@
 import uuid
 from datetime import datetime
+from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, EmailStr
 
 from apps.users.schemas import UserSchema
 
@@ -13,6 +14,75 @@ class MemberSchema(BaseModel):
     user: UserSchema
 
     model_config = {"from_attributes": True}
+
+
+class AdminMemberSchema(BaseModel):
+    """Flattened member row for the PulseFit staff admin."""
+
+    id: uuid.UUID
+    user_id: uuid.UUID
+    first_name: str | None = None
+    last_name: str | None = None
+    email: str | None = None
+    phone_number: str | None = None
+    username: str | None = None
+    gender: str | None = None
+    is_active: bool = True
+    last_login: datetime | None = None
+    class_credits: int = 0
+    reservation_count: int = 0
+    created: datetime
+    modified: datetime
+
+    model_config = {"from_attributes": True}
+
+    @classmethod
+    def from_member(cls, member, *, reservation_count: int | None = None) -> "AdminMemberSchema":
+        user = member.user
+        wallet = getattr(user, "wallet", None)
+        count = reservation_count
+        if count is None:
+            count = getattr(member, "reservation_count", None)
+        if count is None:
+            count = member.reservations.count()
+        return cls(
+            id=member.id,
+            user_id=user.id,
+            first_name=user.first_name,
+            last_name=user.last_name,
+            email=user.email,
+            phone_number=getattr(user, "phone_number", None),
+            username=user.username,
+            gender=getattr(user, "gender", None) or None,
+            is_active=bool(user.is_active),
+            last_login=user.last_login,
+            class_credits=int(getattr(wallet, "class_credits", 0) or 0),
+            reservation_count=int(count or 0),
+            created=member.created,
+            modified=member.modified,
+        )
+
+
+class AdminMemberUpdateSchema(BaseModel):
+    """Partial payload for staff member edits."""
+
+    first_name: str | None = None
+    last_name: str | None = None
+    email: EmailStr | None = None
+    phone_number: str | None = None
+    gender: Optional[str] = None
+    is_active: bool | None = None
+
+
+class AdminMemberCreateSchema(BaseModel):
+    """Payload to register a member from the staff admin."""
+
+    email: EmailStr
+    password: str
+    first_name: str
+    last_name: str
+    phone_number: str
+    gender: Optional[str] = None
 
 
 class ReservationSchema(BaseModel):

--- a/apps/members/services.py
+++ b/apps/members/services.py
@@ -1,8 +1,22 @@
 from uuid import UUID
 
+from django.contrib.auth import get_user_model
+from django.db.models import Count, Q
+from django.shortcuts import get_object_or_404
+
 from apps.members import members
-from apps.members.schemas import MemberSchema, ReservationSchema
+from apps.members.models import Member
+from apps.members.schemas import (
+    AdminMemberSchema,
+    MemberSchema,
+    ReservationSchema,
+)
 from apps.users.services import get_or_create_user as _get_or_create_user
+
+User = get_user_model()
+
+USER_ADMIN_FIELDS = {"first_name", "last_name", "email", "phone_number", "gender", "is_active"}
+GENDER_VALUES = {"", "female", "male", "other"}
 
 
 def get_or_create_user(validated_data: dict):
@@ -22,6 +36,129 @@ def get_or_create_member_user(validated_data: dict) -> tuple[MemberSchema, bool]
     """
     member, created = members.get_or_create_member_user(validated_data)
     return MemberSchema.model_validate(member), created
+
+
+def _admin_member_dict(member: Member) -> dict:
+    return AdminMemberSchema.from_member(member).model_dump(mode="json")
+
+
+def list_admin_members(
+    *,
+    search: str | None = None,
+    status: str | None = None,
+) -> list[dict]:
+    """Return members for the staff admin list."""
+    queryset = (
+        Member.objects.select_related("user", "user__wallet")
+        .annotate(reservation_count=Count("reservations"))
+        .order_by("user__first_name", "user__last_name", "user__email")
+    )
+
+    if status == "active":
+        queryset = queryset.filter(user__is_active=True)
+    elif status == "inactive":
+        queryset = queryset.filter(user__is_active=False)
+
+    term = (search or "").strip()
+    if term:
+        queryset = queryset.filter(
+            Q(user__first_name__icontains=term)
+            | Q(user__last_name__icontains=term)
+            | Q(user__email__icontains=term)
+            | Q(user__username__icontains=term)
+            | Q(user__phone_number__icontains=term)
+        )
+
+    return [_admin_member_dict(member) for member in queryset]
+
+
+def get_admin_member(*, member_id: str | UUID) -> dict:
+    """Return one member for the staff admin."""
+    member = get_object_or_404(
+        Member.objects.select_related("user", "user__wallet").annotate(
+            reservation_count=Count("reservations")
+        ),
+        id=member_id,
+    )
+    return _admin_member_dict(member)
+
+
+def _apply_admin_member_fields(member: Member, data: dict) -> Member:
+    user = member.user
+    user_dirty: list[str] = []
+    sync_username = bool(user.username) and user.username == (user.email or "")
+
+    if "gender" in data and data["gender"] is not None and data["gender"] not in GENDER_VALUES:
+        raise ValueError("Género inválido.")
+
+    if "email" in data:
+        email = (data["email"] or "").strip()
+        if not email:
+            raise ValueError("El correo electrónico es obligatorio.")
+        taken = (
+            User.objects.filter(is_removed=False)
+            .filter(Q(email__iexact=email) | Q(username__iexact=email))
+            .exclude(id=user.id)
+            .exists()
+        )
+        if taken:
+            raise ValueError("Ya existe un usuario con ese correo.")
+
+    for field, value in data.items():
+        if field not in USER_ADMIN_FIELDS:
+            continue
+        if field == "email":
+            value = (value or "").strip()
+            if sync_username:
+                user.username = value
+                user_dirty.append("username")
+        elif field in {"first_name", "last_name", "phone_number", "gender"} and value is None:
+            value = ""
+        setattr(user, field, value)
+        user_dirty.append(field)
+
+    if user_dirty:
+        user.save(update_fields=list(dict.fromkeys(user_dirty)))
+
+    return member
+
+
+def update_admin_member(*, member_id: str | UUID, data: dict) -> dict:
+    """Update staff-editable member user fields."""
+    member = get_object_or_404(
+        Member.objects.select_related("user", "user__wallet"),
+        id=member_id,
+    )
+    member = _apply_admin_member_fields(member, data)
+    member = get_object_or_404(
+        Member.objects.select_related("user", "user__wallet").annotate(
+            reservation_count=Count("reservations")
+        ),
+        id=member_id,
+    )
+    return _admin_member_dict(member)
+
+
+def create_admin_member(*, data: dict) -> tuple[dict, bool]:
+    """Create (or fetch) a member from the staff admin and return the admin payload."""
+    payload = dict(data)
+    gender = payload.pop("gender", None)
+    member_schema, created = get_or_create_member_user(payload)
+    member = get_object_or_404(
+        Member.objects.select_related("user", "user__wallet").annotate(
+            reservation_count=Count("reservations")
+        ),
+        id=member_schema.id,
+    )
+    if gender is not None and created:
+        member = _apply_admin_member_fields(member, {"gender": gender})
+        member = get_object_or_404(
+            Member.objects.select_related("user", "user__wallet").annotate(
+                reservation_count=Count("reservations")
+            ),
+            id=member.id,
+        )
+    return _admin_member_dict(member), created
 
 
 def create_reservation(validated_data: dict) -> ReservationSchema:
@@ -44,7 +181,6 @@ def change_reservation_spot(schedule_id: str, user_id: str, new_spot: int) -> Re
 
 def list_reservations(validated_query: dict) -> list[ReservationSchema]:
     """Application service: list reservations via domain and return schemas."""
-    # Map serializer field names to function parameter names
     query_params = {}
     if "start_date" in validated_query:
         query_params["start_date"] = validated_query["start_date"]

--- a/apps/members/tests/test_admin_views.py
+++ b/apps/members/tests/test_admin_views.py
@@ -1,0 +1,152 @@
+"""API tests for staff admin member endpoints."""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from drf_expiring_token.models import ExpiringToken
+
+from apps.members.models import Member
+from apps.wallets.models import Wallet
+
+User = get_user_model()
+
+
+@pytest.fixture
+def staff_client(api_client):
+    staff_user = User.objects.create_user(
+        username="adminuser",
+        email="admin@example.com",
+        password="testpass123",
+        is_staff=True,
+    )
+    token = ExpiringToken.objects.create(user=staff_user)
+    api_client.credentials(HTTP_AUTHORIZATION=f"Token {token.key}")
+    return api_client, staff_user
+
+
+@pytest.fixture
+def member_user(db):
+    user = User.objects.create_user(
+        username="socio@example.com",
+        email="socio@example.com",
+        password="pass1234",
+        first_name="Ana",
+        last_name="Ríos",
+        phone_number="+56911112222",
+        gender="female",
+    )
+    member = Member.objects.create(user=user)
+    Wallet.objects.create(user=user, class_credits=5)
+    return member
+
+
+@pytest.mark.django_db
+class TestAdminMemberListView:
+    def test_requires_authentication(self, api_client):
+        response = api_client.get(reverse("admin-members"))
+        assert response.status_code == 401
+
+    def test_requires_staff(self, api_client, member_user):
+        token = ExpiringToken.objects.create(user=member_user.user)
+        api_client.credentials(HTTP_AUTHORIZATION=f"Token {token.key}")
+
+        response = api_client.get(reverse("admin-members"))
+        assert response.status_code == 403
+
+    def test_returns_list_for_staff(self, staff_client, member_user):
+        client, _ = staff_client
+        response = client.get(reverse("admin-members"))
+
+        assert response.status_code == 200
+        ids = {row["id"] for row in response.data}
+        assert str(member_user.id) in ids
+        match = next(row for row in response.data if row["id"] == str(member_user.id))
+        assert match["email"] == "socio@example.com"
+        assert match["class_credits"] == 5
+        assert match["first_name"] == "Ana"
+
+    def test_filters_by_status_and_search(self, staff_client, member_user):
+        client, _ = staff_client
+        inactive_user = User.objects.create_user(
+            username="inactive@example.com",
+            email="inactive@example.com",
+            password="pass1234",
+            first_name="Bob",
+            is_active=False,
+        )
+        Member.objects.create(user=inactive_user)
+
+        active_response = client.get(reverse("admin-members"), {"status": "active"})
+        assert active_response.status_code == 200
+        assert all(row["is_active"] is True for row in active_response.data)
+        assert str(member_user.id) in {row["id"] for row in active_response.data}
+
+        search_response = client.get(reverse("admin-members"), {"search": "Ana"})
+        assert search_response.status_code == 200
+        assert [row["email"] for row in search_response.data] == ["socio@example.com"]
+
+    def test_create_member(self, staff_client):
+        client, _ = staff_client
+        response = client.post(
+            reverse("admin-members"),
+            data={
+                "email": "nuevo@example.com",
+                "password": "Secret123!",
+                "first_name": "Luna",
+                "last_name": "Pérez",
+                "phone_number": "+56999998888",
+                "gender": "female",
+            },
+            format="json",
+        )
+
+        assert response.status_code == 201
+        assert response.data["email"] == "nuevo@example.com"
+        assert response.data["first_name"] == "Luna"
+        assert response.data["gender"] == "female"
+        assert Member.objects.filter(user__email="nuevo@example.com").exists()
+
+
+@pytest.mark.django_db
+class TestAdminMemberDetailView:
+    def test_detail_requires_staff(self, api_client, member_user):
+        token = ExpiringToken.objects.create(user=member_user.user)
+        api_client.credentials(HTTP_AUTHORIZATION=f"Token {token.key}")
+
+        response = api_client.get(
+            reverse("admin-member-detail", kwargs={"member_id": member_user.id})
+        )
+        assert response.status_code == 403
+
+    def test_detail_returns_member(self, staff_client, member_user):
+        client, _ = staff_client
+        response = client.get(reverse("admin-member-detail", kwargs={"member_id": member_user.id}))
+
+        assert response.status_code == 200
+        assert response.data["id"] == str(member_user.id)
+        assert response.data["email"] == member_user.user.email
+        assert response.data["class_credits"] == 5
+
+    def test_patch_updates_fields(self, staff_client, member_user):
+        client, _ = staff_client
+        url = reverse("admin-member-detail", kwargs={"member_id": member_user.id})
+        response = client.patch(
+            url,
+            data={
+                "first_name": "Anita",
+                "phone_number": "+56900001111",
+                "is_active": False,
+                "gender": "other",
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200
+        assert response.data["first_name"] == "Anita"
+        assert response.data["phone_number"] == "+56900001111"
+        assert response.data["is_active"] is False
+        assert response.data["gender"] == "other"
+
+        member_user.user.refresh_from_db()
+        assert member_user.user.first_name == "Anita"
+        assert member_user.user.is_active is False

--- a/apps/members/urls.py
+++ b/apps/members/urls.py
@@ -1,8 +1,19 @@
 from django.urls import path
 
-from apps.members.views import MemberView, ReservationView
+from apps.members.views import (
+    AdminMemberDetailView,
+    AdminMemberListView,
+    MemberView,
+    ReservationView,
+)
 
 urlpatterns = [
+    path("admin/", AdminMemberListView.as_view(), name="admin-members"),
+    path(
+        "admin/<uuid:member_id>/",
+        AdminMemberDetailView.as_view(),
+        name="admin-member-detail",
+    ),
     path("register/", MemberView.as_view({"post": "create"}), name="member-register"),
     path(
         "get_member/",

--- a/apps/members/views.py
+++ b/apps/members/views.py
@@ -1,8 +1,10 @@
 from datetime import date
 
+from pydantic import ValidationError as PydanticValidationError
 from rest_framework import status
-from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.permissions import AllowAny, IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.views import APIView
 from rest_framework.viewsets import ViewSet
 
 from apps.members import constants
@@ -11,6 +13,7 @@ from apps.members.exceptions import (
     RoomFullException,
     ReservationInvalidStateException,
 )
+from apps.members.schemas import AdminMemberCreateSchema, AdminMemberUpdateSchema
 from apps.members.serializers import (
     MemberSerializer,
     ReservationSerializer,
@@ -19,14 +22,27 @@ from apps.members.serializers import (
     ReservationCancelSerializer,
 )
 from apps.members.services import (
+    create_admin_member,
+    get_admin_member,
     get_or_create_member_user,
     get_member_from_user_id,
     create_reservation,
     cancel_reservation,
     change_reservation_spot,
+    list_admin_members,
     list_reservations,
+    update_admin_member,
 )
 from apps.members.models import Member, Reservation
+
+
+def _pydantic_error_response(exc: PydanticValidationError) -> Response:
+    first = exc.errors()[0] if exc.errors() else {}
+    loc = ".".join(str(part) for part in first.get("loc", [])) or "payload"
+    return Response(
+        {"detail": f"{loc}: {first.get('msg', 'Datos inválidos.')}"},
+        status=status.HTTP_400_BAD_REQUEST,
+    )
 
 
 class MemberView(ViewSet):
@@ -91,7 +107,6 @@ class ReservationView(ViewSet):
             data["start_date"] = today.isoformat()
 
         if not has_end_date:
-            # Use a far future date to effectively get all future reservations
             data["end_date"] = date(2100, 1, 1).isoformat()
 
         query_serializer = ReservationListQuerySerializer(data=data)
@@ -132,3 +147,56 @@ class ReservationView(ViewSet):
         except (ReservationInvalidStateException, InvalidSpotException) as exc:
             return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
         return Response(reservation.model_dump(), status=status.HTTP_200_OK)
+
+
+class AdminMemberListView(APIView):
+    """List or create members for the PulseFit admin. Staff only."""
+
+    permission_classes = [IsAuthenticated, IsAdminUser]
+
+    def get(self, request, *args, **kwargs):
+        members_list = list_admin_members(
+            search=request.query_params.get("search"),
+            status=request.query_params.get("status"),
+        )
+        return Response(members_list, status=status.HTTP_200_OK)
+
+    def post(self, request, *args, **kwargs):
+        try:
+            payload = AdminMemberCreateSchema.model_validate(request.data)
+        except PydanticValidationError as exc:
+            return _pydantic_error_response(exc)
+
+        try:
+            member, created = create_admin_member(data=payload.model_dump())
+        except ValueError as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+        return Response(
+            member,
+            status=status.HTTP_201_CREATED if created else status.HTTP_200_OK,
+        )
+
+
+class AdminMemberDetailView(APIView):
+    """Retrieve or update a member for the PulseFit admin. Staff only."""
+
+    permission_classes = [IsAuthenticated, IsAdminUser]
+    http_method_names = ["get", "patch", "head", "options"]
+
+    def get(self, request, member_id, *args, **kwargs):
+        return Response(get_admin_member(member_id=member_id), status=status.HTTP_200_OK)
+
+    def patch(self, request, member_id, *args, **kwargs):
+        try:
+            payload = AdminMemberUpdateSchema.model_validate(request.data)
+        except PydanticValidationError as exc:
+            return _pydantic_error_response(exc)
+
+        try:
+            member = update_admin_member(
+                member_id=member_id,
+                data=payload.model_dump(exclude_unset=True),
+            )
+        except ValueError as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+        return Response(member, status=status.HTTP_200_OK)


### PR DESCRIPTION
## Summary
- Add staff-only `/api/members/admin/` list/create and `/api/members/admin/<id>/` detail/update endpoints
- Return flattened socio payloads with credits, reservation counts, and active filters
- Cover the new APIs with staff permission and CRUD tests

## Test plan
- [ ] `pytest apps/members/tests/test_admin_views.py`
- [ ] Staff token can list/search/filter members
- [ ] Non-staff gets 403
- [ ] Create and PATCH update a member from the admin API


Made with [Cursor](https://cursor.com)