### PR TITLE
feat(members): add staff admin APIs for reservations

### DIFF
--- a/apps/members/members.py
+++ b/apps/members/members.py
@@ -1,5 +1,5 @@
 from django.db import transaction
-from django.db.models import QuerySet
+from django.db.models import Q, QuerySet
 
 from apps.members import constants
 from apps.members.exceptions import (
@@ -11,6 +11,13 @@ from apps.members.models import Member, Reservation
 from apps.schedules.schedules import get_schedule_by_id
 from apps.users.services import get_or_create_user
 from apps.verifications.services import create_verification_code
+
+ADMIN_RESERVATION_STATUSES = {
+    constants.RESERVATION_STATUS_RESERVED,
+    constants.RESERVATION_STATUS_CANCELLED,
+    constants.RESERVATION_STATUS_ATTENDED,
+    constants.RESERVATION_STATUS_MISSED,
+}
 
 
 def get_member_by_id(member_id: str) -> Member:
@@ -218,4 +225,67 @@ def list_reservations_by_date_range(
     # Exclude cancelled reservations
     return Reservation.objects.filter(**filters).exclude(
         status=constants.RESERVATION_STATUS_CANCELLED
+    )
+
+
+def list_admin_reservations(
+    *,
+    start_date=None,
+    end_date=None,
+    member_id=None,
+    schedule_id=None,
+    instructor_id=None,
+    room_id=None,
+    status=None,
+    search=None,
+) -> QuerySet[Reservation]:
+    """
+    Return reservations for the staff admin, including cancelled rows.
+
+    Unlike the member-facing list, cancelled reservations are kept unless
+    a specific status filter is applied.
+    """
+    filters = {"is_removed": False}
+
+    if schedule_id is not None:
+        filters["schedule_id"] = schedule_id
+    elif start_date is not None and end_date is not None:
+        filters["schedule__start_time__date__range"] = (start_date, end_date)
+
+    if member_id is not None:
+        filters["member_id"] = member_id
+    if instructor_id is not None:
+        filters["schedule__instructor_id"] = instructor_id
+    if room_id is not None:
+        filters["schedule__room_id"] = room_id
+    if status in ADMIN_RESERVATION_STATUSES:
+        filters["status"] = status
+
+    queryset = Reservation.objects.filter(**filters).select_related(
+        "member__user",
+        "schedule__instructor__user",
+        "schedule__room__studio",
+    )
+
+    if search:
+        term = search.strip()
+        if term:
+            queryset = queryset.filter(
+                Q(member__user__email__icontains=term)
+                | Q(member__user__username__icontains=term)
+                | Q(member__user__first_name__icontains=term)
+                | Q(member__user__last_name__icontains=term)
+                | Q(schedule__title__icontains=term)
+            )
+
+    return queryset.order_by("schedule__start_time", "spot", "created")
+
+
+def change_reservation_spot_by_id(reservation_id: str, new_spot: int) -> Reservation:
+    """Change spot for a reservation identified by its id."""
+    reservation = get_reservation_by_id(reservation_id)
+    return change_reservation_spot(
+        str(reservation.schedule_id),
+        str(reservation.member.user_id),
+        new_spot,
     )

--- a/apps/members/schemas.py
+++ b/apps/members/schemas.py
@@ -95,3 +95,47 @@ class ReservationSchema(BaseModel):
     spot: int | None = None
 
     model_config = {"from_attributes": True}
+
+
+class AdminReservationSchema(BaseModel):
+    """Enriched reservation row for the PulseFit staff admin."""
+
+    id: uuid.UUID
+    created: datetime
+    modified: datetime
+    member_id: uuid.UUID
+    member_name: str = ""
+    member_email: str = ""
+    user_id: uuid.UUID | None = None
+    schedule_id: uuid.UUID
+    schedule_title: str = ""
+    schedule_start_time: datetime
+    duration_minutes: int
+    instructor_id: uuid.UUID | None = None
+    instructor_name: str = ""
+    room_id: uuid.UUID | None = None
+    room_name: str = ""
+    studio_id: uuid.UUID | None = None
+    studio_name: str | None = None
+    room_capacity: int | None = None
+    status: str
+    spot: int | None = None
+    notes: str = ""
+
+    model_config = {"from_attributes": True}
+
+
+class AdminReservationWriteSchema(BaseModel):
+    """Create a reservation for a member from the staff admin."""
+
+    schedule_id: uuid.UUID
+    spot: int
+    notes: str | None = None
+    user_id: uuid.UUID | None = None
+    member_id: uuid.UUID | None = None
+
+
+class AdminReservationChangeSpotSchema(BaseModel):
+    """Change the bike spot of an existing reservation."""
+
+    new_spot: int

--- a/apps/members/services.py
+++ b/apps/members/services.py
@@ -1,3 +1,4 @@
+from datetime import date
 from uuid import UUID
 
 from django.contrib.auth import get_user_model
@@ -5,9 +6,10 @@ from django.db.models import Count, Q
 from django.shortcuts import get_object_or_404
 
 from apps.members import members
-from apps.members.models import Member
+from apps.members.models import Member, Reservation
 from apps.members.schemas import (
     AdminMemberSchema,
+    AdminReservationSchema,
     MemberSchema,
     ReservationSchema,
 )
@@ -197,3 +199,161 @@ def list_reservations(validated_query: dict) -> list[ReservationSchema]:
 
     qs = members.list_reservations_by_date_range(**query_params)
     return [ReservationSchema.model_validate(obj) for obj in qs]
+
+
+def _member_display_name(user) -> str:
+    if not user:
+        return ""
+    name = " ".join(part for part in [user.first_name, user.last_name] if part).strip()
+    return name or user.username or user.email or ""
+
+
+def _instructor_display_name(schedule) -> str:
+    instructor = getattr(schedule, "instructor", None)
+    user = getattr(instructor, "user", None) if instructor else None
+    return _member_display_name(user)
+
+
+def _serialize_admin_reservation(reservation: Reservation) -> dict:
+    member = reservation.member
+    user = getattr(member, "user", None)
+    schedule = reservation.schedule
+    room = getattr(schedule, "room", None)
+    studio = getattr(room, "studio", None) if room else None
+
+    payload = {
+        "id": reservation.id,
+        "created": reservation.created,
+        "modified": reservation.modified,
+        "member_id": reservation.member_id,
+        "member_name": _member_display_name(user),
+        "member_email": getattr(user, "email", "") or "",
+        "user_id": getattr(user, "id", None),
+        "schedule_id": reservation.schedule_id,
+        "schedule_title": schedule.title or "",
+        "schedule_start_time": schedule.start_time,
+        "duration_minutes": schedule.duration_minutes,
+        "instructor_id": schedule.instructor_id,
+        "instructor_name": _instructor_display_name(schedule),
+        "room_id": schedule.room_id,
+        "room_name": room.name if room else "",
+        "studio_id": studio.id if studio else None,
+        "studio_name": studio.name if studio else None,
+        "room_capacity": room.capacity if room else None,
+        "status": reservation.status,
+        "spot": reservation.spot,
+        "notes": reservation.notes or "",
+    }
+    return AdminReservationSchema.model_validate(payload).model_dump(mode="json")
+
+
+def _parse_date(value: str | None, field_name: str) -> date | None:
+    if not value:
+        return None
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise ValueError(f"{field_name} must be YYYY-MM-DD.") from exc
+
+
+def list_admin_reservations(
+    *,
+    start_date: str | date | None = None,
+    end_date: str | date | None = None,
+    member_id: str | UUID | None = None,
+    schedule_id: str | UUID | None = None,
+    instructor_id: str | UUID | None = None,
+    room_id: str | UUID | None = None,
+    status: str | None = None,
+    search: str | None = None,
+) -> list[dict]:
+    """Return enriched reservations for the staff admin list."""
+    parsed_start = (
+        start_date if isinstance(start_date, date) else _parse_date(start_date, "start_date")
+    )
+    parsed_end = end_date if isinstance(end_date, date) else _parse_date(end_date, "end_date")
+
+    if not schedule_id and (parsed_start is None or parsed_end is None):
+        today = date.today()
+        parsed_start = today.fromordinal(today.toordinal() - today.weekday())
+        parsed_end = parsed_start.fromordinal(parsed_start.toordinal() + 6)
+
+    qs = members.list_admin_reservations(
+        start_date=parsed_start,
+        end_date=parsed_end,
+        member_id=member_id,
+        schedule_id=schedule_id,
+        instructor_id=instructor_id,
+        room_id=room_id,
+        status=status,
+        search=search,
+    )
+    return [_serialize_admin_reservation(obj) for obj in qs]
+
+
+def get_admin_reservation(reservation_id: str | UUID) -> dict:
+    """Return one enriched reservation for the staff admin."""
+    try:
+        reservation = (
+            Reservation.objects.select_related(
+                "member__user",
+                "schedule__instructor__user",
+                "schedule__room__studio",
+            )
+            .filter(is_removed=False)
+            .get(id=reservation_id)
+        )
+    except Reservation.DoesNotExist as exc:
+        raise ValueError("Reservation not found.") from exc
+    return _serialize_admin_reservation(reservation)
+
+
+def create_admin_reservation(data: dict) -> dict:
+    """Create a reservation for a given member/user from the staff admin."""
+    user_id = data.get("user_id")
+    member_id = data.get("member_id")
+
+    if not user_id and not member_id:
+        raise ValueError("user_id or member_id is required.")
+    if user_id and member_id:
+        raise ValueError("Provide either user_id or member_id, not both.")
+
+    if member_id:
+        try:
+            member = Member.objects.select_related("user").get(id=member_id, is_removed=False)
+        except Member.DoesNotExist as exc:
+            raise ValueError("Member not found.") from exc
+        user_id = member.user_id
+
+    try:
+        User.objects.get(id=user_id)
+    except User.DoesNotExist as exc:
+        raise ValueError("User not found.") from exc
+
+    reservation = members.create_reservation(
+        {
+            "user_id": user_id,
+            "schedule_id": data["schedule_id"],
+            "spot": data["spot"],
+            "notes": data.get("notes") or "Admin reservation",
+        }
+    )
+    return get_admin_reservation(reservation.id)
+
+
+def cancel_admin_reservation(reservation_id: str | UUID) -> dict:
+    """Cancel a reservation from the staff admin."""
+    try:
+        members.cancel_reservation(str(reservation_id))
+    except Reservation.DoesNotExist as exc:
+        raise ValueError("Reservation not found.") from exc
+    return get_admin_reservation(reservation_id)
+
+
+def change_admin_reservation_spot(reservation_id: str | UUID, new_spot: int) -> dict:
+    """Change the spot of a reservation from the staff admin."""
+    try:
+        members.change_reservation_spot_by_id(str(reservation_id), new_spot)
+    except Reservation.DoesNotExist as exc:
+        raise ValueError("Reservation not found.") from exc
+    return get_admin_reservation(reservation_id)

--- a/apps/members/tests/test_admin_reservation_views.py
+++ b/apps/members/tests/test_admin_reservation_views.py
@@ -1,0 +1,217 @@
+"""API tests for staff admin reservation endpoints."""
+
+from datetime import datetime, timezone
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from drf_expiring_token.models import ExpiringToken
+from model_bakery import baker
+from rest_framework import status
+
+from apps.members import constants as member_constants
+from apps.members.models import Member, Reservation
+
+User = get_user_model()
+
+
+@pytest.fixture
+def staff_user():
+    return User.objects.create_user(
+        username="reservationadmin",
+        email="reservationadmin@example.com",
+        password="pass1234",
+        is_staff=True,
+    )
+
+
+@pytest.fixture
+def staff_client(api_client, staff_user):
+    token = ExpiringToken.objects.create(user=staff_user)
+    api_client.credentials(HTTP_AUTHORIZATION=f"Token {token.key}")
+    return api_client
+
+
+@pytest.fixture
+def reservation_graph(db):
+    instructor = baker.make(
+        "instructors.Instructor",
+        user__username="coach",
+        user__email="coach@example.com",
+        user__first_name="Coach",
+        user__last_name="One",
+    )
+    room = baker.make("studios.Room", name="Sala A", capacity=20)
+    schedule = baker.make(
+        "schedules.Schedule",
+        title="RIDE 45",
+        instructor=instructor,
+        room=room,
+        start_time=datetime(2025, 6, 2, 10, 0, tzinfo=timezone.utc),
+        duration_minutes=45,
+        status="scheduled",
+    )
+    user = User.objects.create_user(
+        username="socio@example.com",
+        email="socio@example.com",
+        password="pass1234",
+        first_name="Ana",
+        last_name="Ríos",
+    )
+    member = Member.objects.create(user=user)
+    reservation = Reservation.objects.create(
+        member=member,
+        schedule=schedule,
+        spot=3,
+        status=member_constants.RESERVATION_STATUS_RESERVED,
+        notes="Walk-in",
+    )
+    return {
+        "instructor": instructor,
+        "room": room,
+        "schedule": schedule,
+        "user": user,
+        "member": member,
+        "reservation": reservation,
+    }
+
+
+@pytest.mark.django_db
+class TestAdminReservationViews:
+    def test_list_requires_staff(self, api_client, reservation_graph):
+        user = User.objects.create_user(
+            username="member",
+            email="member@example.com",
+            password="pass1234",
+        )
+        token = ExpiringToken.objects.create(user=user)
+        api_client.credentials(HTTP_AUTHORIZATION=f"Token {token.key}")
+
+        response = api_client.get(reverse("admin-reservation-list"))
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_list_returns_enriched_rows(self, staff_client, reservation_graph):
+        reservation = reservation_graph["reservation"]
+        response = staff_client.get(
+            reverse("admin-reservation-list"),
+            {
+                "start_date": "2025-06-01",
+                "end_date": "2025-06-07",
+            },
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 1
+        row = response.data[0]
+        assert row["id"] == str(reservation.id)
+        assert row["member_email"] == "socio@example.com"
+        assert row["member_name"] == "Ana Ríos"
+        assert row["schedule_title"] == "RIDE 45"
+        assert row["room_name"] == "Sala A"
+        assert row["spot"] == 3
+        assert row["status"] == member_constants.RESERVATION_STATUS_RESERVED
+
+    def test_list_includes_cancelled_and_filters_status(self, staff_client, reservation_graph):
+        reservation = reservation_graph["reservation"]
+        reservation.status = member_constants.RESERVATION_STATUS_CANCELLED
+        reservation.save(update_fields=["status"])
+
+        all_response = staff_client.get(
+            reverse("admin-reservation-list"),
+            {"start_date": "2025-06-01", "end_date": "2025-06-07"},
+        )
+        assert all_response.status_code == status.HTTP_200_OK
+        assert len(all_response.data) == 1
+
+        reserved_response = staff_client.get(
+            reverse("admin-reservation-list"),
+            {
+                "start_date": "2025-06-01",
+                "end_date": "2025-06-07",
+                "status": member_constants.RESERVATION_STATUS_RESERVED,
+            },
+        )
+        assert reserved_response.status_code == status.HTTP_200_OK
+        assert reserved_response.data == []
+
+        cancelled_response = staff_client.get(
+            reverse("admin-reservation-list"),
+            {
+                "start_date": "2025-06-01",
+                "end_date": "2025-06-07",
+                "status": member_constants.RESERVATION_STATUS_CANCELLED,
+            },
+        )
+        assert cancelled_response.status_code == status.HTTP_200_OK
+        assert len(cancelled_response.data) == 1
+
+    def test_list_search_by_email(self, staff_client, reservation_graph):
+        response = staff_client.get(
+            reverse("admin-reservation-list"),
+            {
+                "start_date": "2025-06-01",
+                "end_date": "2025-06-07",
+                "search": "socio@",
+            },
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 1
+
+        miss = staff_client.get(
+            reverse("admin-reservation-list"),
+            {
+                "start_date": "2025-06-01",
+                "end_date": "2025-06-07",
+                "search": "nobody",
+            },
+        )
+        assert miss.status_code == status.HTTP_200_OK
+        assert miss.data == []
+
+    def test_create_cancel_and_change_spot(self, staff_client, reservation_graph):
+        schedule = reservation_graph["schedule"]
+        other_user = User.objects.create_user(
+            username="otro@example.com",
+            email="otro@example.com",
+            password="pass1234",
+            first_name="Luis",
+            last_name="Pérez",
+        )
+
+        create_response = staff_client.post(
+            reverse("admin-reservation-list"),
+            {
+                "user_id": str(other_user.id),
+                "schedule_id": str(schedule.id),
+                "spot": 7,
+                "notes": "Admin booking",
+            },
+            format="json",
+        )
+        assert create_response.status_code == status.HTTP_201_CREATED
+        assert create_response.data["spot"] == 7
+        assert create_response.data["member_email"] == "otro@example.com"
+        reservation_id = create_response.data["id"]
+
+        change_response = staff_client.patch(
+            reverse("admin-reservation-change-spot", kwargs={"reservation_id": reservation_id}),
+            {"new_spot": 8},
+            format="json",
+        )
+        assert change_response.status_code == status.HTTP_200_OK
+        assert change_response.data["spot"] == 8
+
+        cancel_response = staff_client.post(
+            reverse("admin-reservation-cancel", kwargs={"reservation_id": reservation_id}),
+            format="json",
+        )
+        assert cancel_response.status_code == status.HTTP_200_OK
+        assert cancel_response.data["status"] == member_constants.RESERVATION_STATUS_CANCELLED
+
+    def test_detail_not_found(self, staff_client):
+        response = staff_client.get(
+            reverse(
+                "admin-reservation-detail",
+                kwargs={"reservation_id": "00000000-0000-0000-0000-000000000001"},
+            )
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/apps/members/urls.py
+++ b/apps/members/urls.py
@@ -3,11 +3,35 @@ from django.urls import path
 from apps.members.views import (
     AdminMemberDetailView,
     AdminMemberListView,
+    AdminReservationCancelView,
+    AdminReservationChangeSpotView,
+    AdminReservationDetailView,
+    AdminReservationListView,
     MemberView,
     ReservationView,
 )
 
 urlpatterns = [
+    path(
+        "admin/reservations/",
+        AdminReservationListView.as_view(),
+        name="admin-reservation-list",
+    ),
+    path(
+        "admin/reservations/<uuid:reservation_id>/",
+        AdminReservationDetailView.as_view(),
+        name="admin-reservation-detail",
+    ),
+    path(
+        "admin/reservations/<uuid:reservation_id>/cancel/",
+        AdminReservationCancelView.as_view(),
+        name="admin-reservation-cancel",
+    ),
+    path(
+        "admin/reservations/<uuid:reservation_id>/change-spot/",
+        AdminReservationChangeSpotView.as_view(),
+        name="admin-reservation-change-spot",
+    ),
     path("admin/", AdminMemberListView.as_view(), name="admin-members"),
     path(
         "admin/<uuid:member_id>/",

--- a/apps/members/views.py
+++ b/apps/members/views.py
@@ -13,7 +13,12 @@ from apps.members.exceptions import (
     RoomFullException,
     ReservationInvalidStateException,
 )
-from apps.members.schemas import AdminMemberCreateSchema, AdminMemberUpdateSchema
+from apps.members.schemas import (
+    AdminMemberCreateSchema,
+    AdminMemberUpdateSchema,
+    AdminReservationChangeSpotSchema,
+    AdminReservationWriteSchema,
+)
 from apps.members.serializers import (
     MemberSerializer,
     ReservationSerializer,
@@ -32,6 +37,11 @@ from apps.members.services import (
     list_admin_members,
     list_reservations,
     update_admin_member,
+    list_admin_reservations,
+    get_admin_reservation,
+    create_admin_reservation,
+    cancel_admin_reservation,
+    change_admin_reservation_spot,
 )
 from apps.members.models import Member, Reservation
 
@@ -200,3 +210,98 @@ class AdminMemberDetailView(APIView):
         except ValueError as exc:
             return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
         return Response(member, status=status.HTTP_200_OK)
+
+
+class AdminReservationListView(APIView):
+    """List or create reservations for the PulseFit admin. Staff only."""
+
+    permission_classes = [IsAuthenticated, IsAdminUser]
+
+    def get(self, request, *args, **kwargs):
+        try:
+            reservations = list_admin_reservations(
+                start_date=request.query_params.get("start_date"),
+                end_date=request.query_params.get("end_date"),
+                member_id=request.query_params.get("member_id"),
+                schedule_id=request.query_params.get("schedule_id"),
+                instructor_id=request.query_params.get("instructor_id"),
+                room_id=request.query_params.get("room_id"),
+                status=request.query_params.get("status"),
+                search=request.query_params.get("search"),
+            )
+        except ValueError as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+        return Response(reservations, status=status.HTTP_200_OK)
+
+    def post(self, request, *args, **kwargs):
+        try:
+            payload = AdminReservationWriteSchema.model_validate(request.data)
+        except PydanticValidationError as exc:
+            return _pydantic_error_response(exc)
+
+        try:
+            reservation = create_admin_reservation(data=payload.model_dump(exclude_unset=True))
+        except ValueError as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+        except RoomFullException as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+        except InvalidSpotException as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+        return Response(reservation, status=status.HTTP_201_CREATED)
+
+
+class AdminReservationDetailView(APIView):
+    """Retrieve a reservation for the PulseFit admin. Staff only."""
+
+    permission_classes = [IsAuthenticated, IsAdminUser]
+
+    def get(self, request, reservation_id, *args, **kwargs):
+        try:
+            reservation = get_admin_reservation(reservation_id=reservation_id)
+        except ValueError as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_404_NOT_FOUND)
+        return Response(reservation, status=status.HTTP_200_OK)
+
+
+class AdminReservationCancelView(APIView):
+    """Cancel a reservation from the staff admin."""
+
+    permission_classes = [IsAuthenticated, IsAdminUser]
+
+    def post(self, request, reservation_id, *args, **kwargs):
+        try:
+            reservation = cancel_admin_reservation(reservation_id=reservation_id)
+        except ValueError as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_404_NOT_FOUND)
+        except ReservationInvalidStateException as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+        return Response(
+            {
+                "message": constants.RESERVATION_CANCELLED_SUCCESS_MESSAGE,
+                **reservation,
+            },
+            status=status.HTTP_200_OK,
+        )
+
+
+class AdminReservationChangeSpotView(APIView):
+    """Change the spot of a reservation from the staff admin."""
+
+    permission_classes = [IsAuthenticated, IsAdminUser]
+
+    def patch(self, request, reservation_id, *args, **kwargs):
+        try:
+            payload = AdminReservationChangeSpotSchema.model_validate(request.data)
+        except PydanticValidationError as exc:
+            return _pydantic_error_response(exc)
+
+        try:
+            reservation = change_admin_reservation_spot(
+                reservation_id=reservation_id,
+                new_spot=payload.new_spot,
+            )
+        except ValueError as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_404_NOT_FOUND)
+        except (ReservationInvalidStateException, InvalidSpotException) as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+        return Response(reservation, status=status.HTTP_200_OK)


### PR DESCRIPTION
## Summary
- Adds staff-only admin endpoints for reservations under `/api/members/admin/reservations/`
- Enriched list/detail with member, schedule, room, and instructor labels
- Supports create, cancel, and change-spot for operational booking management

## Test plan
- [ ] `pytest apps/members/tests/test_admin_reservation_views.py`
- [ ] Staff token can list/filter/search reservations
- [ ] Non-staff receives 403
- [ ] Create / change-spot / cancel flows succeed for RESERVED rows

Made with [Cursor](https://cursor.com)