### PR TITLE
fix(auth): stop SQLite lock 500s on parallel admin GETs

### DIFF
--- a/adminstudio_django/settings/base.py
+++ b/adminstudio_django/settings/base.py
@@ -99,6 +99,10 @@ DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
         "NAME": BASE_DIR / "db.sqlite3",
+        # Wait for the lock instead of 500-ing when parallel admin requests
+        # authenticate at the same time (token sliding expiry used to write
+        # on every request).
+        "OPTIONS": {"timeout": 20},
     }
 }
 
@@ -129,7 +133,7 @@ REST_FRAMEWORK = {
         "rest_framework.renderers.JSONRenderer",
     ],
     "DEFAULT_AUTHENTICATION_CLASSES": [
-        "drf_expiring_token.authentication.ExpiringTokenAuthentication",
+        "apps.users.authentication.ExpiringTokenAuthentication",
         "rest_framework.authentication.SessionAuthentication",
     ],
     "DEFAULT_PERMISSION_CLASSES": [

--- a/adminstudio_django/settings/prod.py
+++ b/adminstudio_django/settings/prod.py
@@ -23,5 +23,6 @@ DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
         "NAME": os.path.join("/data", "db.sqlite3"),
+        "OPTIONS": {"timeout": 20},
     }
 }

--- a/apps/analytics/constants.py
+++ b/apps/analytics/constants.py
@@ -24,10 +24,13 @@ EXCLUDED_SCHEDULE_STATUSES = (
 
 CLASS_FORMATS = ("RIDE", "POWER", "YOGA", "SCULPT", "REFORMER")
 
-# Fixed FX used to present the same 7d revenue in CLP / USD / MXN.
+# Fixed FX used to present the same period revenue in CLP / USD / MXN.
 # Source of truth is always CLP (PlanPurchase.price_paid).
 CLP_PER_USD = 950.0
 CLP_PER_MXN = 52.5
+
+DASHBOARD_ALLOWED_DAYS = (7, 14, 30, 60, 90)
+DASHBOARD_DEFAULT_DAYS = 30
 
 DEMO_USERNAME_PREFIX = "demo.dash."
 DEMO_EMAIL_DOMAIN = "pulsefit.demo"

--- a/apps/analytics/management/commands/seed_dashboard_demo.py
+++ b/apps/analytics/management/commands/seed_dashboard_demo.py
@@ -227,8 +227,8 @@ class Command(BaseCommand):
 
     def _schedules_and_reservations(self, rng, instructors, room, members, today):
         schedules = []
-        start_day = today - timedelta(days=34)
-        for offset in range(35):
+        start_day = today - timedelta(days=89)
+        for offset in range(90):
             day = start_day + timedelta(days=offset)
             hours = CLASS_HOURS if day.weekday() < 5 else [9, 10, 18, 19]
             for hour in hours:
@@ -283,7 +283,7 @@ class Command(BaseCommand):
         while spent < target and index < 80:
             member = members[index % len(members)]
             plan = rng.choice(paid_plans)
-            day = today - timedelta(days=rng.randint(0, 6))
+            day = today - timedelta(days=rng.randint(0, 89))
             purchase = PlanPurchase.objects.create(
                 user=member.user,
                 plan=plan,

--- a/apps/analytics/services.py
+++ b/apps/analytics/services.py
@@ -11,6 +11,8 @@ from apps.analytics.constants import (
     CLASS_FORMATS,
     CLP_PER_MXN,
     CLP_PER_USD,
+    DASHBOARD_ALLOWED_DAYS,
+    DASHBOARD_DEFAULT_DAYS,
     DEMO_PLAN_PREFIX,
     EXCLUDED_SCHEDULE_STATUSES,
     OCCUPIED_RESERVATION_STATUSES,
@@ -21,16 +23,16 @@ from apps.schedules.models import Schedule
 from apps.wallets.models import PlanPurchase, Wallet
 
 
-def get_admin_dashboard(*, now=None) -> dict:
+def get_admin_dashboard(*, now=None, days=DASHBOARD_DEFAULT_DAYS) -> dict:
     now = now or timezone.now()
     today = timezone.localtime(now).date()
+    days = days if days in DASHBOARD_ALLOWED_DAYS else DASHBOARD_DEFAULT_DAYS
     week_start = today - timedelta(days=6)
     prev_week_start = today - timedelta(days=13)
     prev_week_end = today - timedelta(days=7)
-    last_30 = today - timedelta(days=29)
-    revenue_start = today - timedelta(days=6)
-    prev_revenue_start = today - timedelta(days=13)
-    prev_revenue_end = today - timedelta(days=7)
+    period_start = today - timedelta(days=days - 1)
+    prev_period_start = period_start - timedelta(days=days)
+    prev_period_end = period_start - timedelta(days=1)
 
     occupied_filter = Q(
         reservations__is_removed=False,
@@ -46,12 +48,12 @@ def get_admin_dashboard(*, now=None) -> dict:
 
     week_schedules = _in_local_date_range(schedules, week_start, today)
     prev_week_schedules = _in_local_date_range(schedules, prev_week_start, prev_week_end)
-    month_schedules = list(_in_local_date_range(schedules, last_30, today))
+    period_schedules = list(_in_local_date_range(schedules, period_start, today))
 
     week_occ = _mean_occupancy(week_schedules)
     prev_week_occ = _mean_occupancy(prev_week_schedules)
 
-    reservations_by_day = _reservation_counts_by_day(last_30, today)
+    reservations_by_day = _reservation_counts_by_day(period_start, today)
     reservations_today = reservations_by_day.get(today, 0)
     reservations_yesterday = reservations_by_day.get(today - timedelta(days=1), 0)
 
@@ -60,9 +62,9 @@ def get_admin_dashboard(*, now=None) -> dict:
     members_week_ago = _active_members_qs(today, created_on_or_before=prev_week_end).count()
     members_delta_pct = _pct_change(active_members, members_week_ago)
 
-    revenue_7d = _revenue_between(revenue_start, today)
-    revenue_prev = _revenue_between(prev_revenue_start, prev_revenue_end)
-    wallet_stats = _wallet_commerce(today, revenue_start, last_30)
+    revenue_period = _revenue_between(period_start, today)
+    revenue_prev = _revenue_between(prev_period_start, prev_period_end)
+    wallet_stats = _wallet_commerce(today, period_start)
 
     return {
         "kpis": {
@@ -81,29 +83,34 @@ def get_admin_dashboard(*, now=None) -> dict:
                 "delta_pct": members_delta_pct,
             },
             "revenue_7d": {
-                "amount_clp": revenue_7d,
-                "amount_usd": _convert_clp(revenue_7d, CLP_PER_USD),
-                "amount_mxn": _convert_clp(revenue_7d, CLP_PER_MXN),
-                "delta_pct": _pct_change(revenue_7d, revenue_prev),
+                "amount_clp": revenue_period,
+                "amount_usd": _convert_clp(revenue_period, CLP_PER_USD),
+                "amount_mxn": _convert_clp(revenue_period, CLP_PER_MXN),
+                "delta_pct": _pct_change(revenue_period, revenue_prev),
                 "fx": {
                     "base": "CLP",
                     "clp_per_usd": CLP_PER_USD,
                     "clp_per_mxn": CLP_PER_MXN,
                 },
             },
-            "purchases_7d": wallet_stats["purchases_7d"],
+            "purchases_7d": wallet_stats["purchases_period"],
             "unlimited_wallets": wallet_stats["unlimited_wallets"],
             "class_credits_outstanding": wallet_stats["class_credits_outstanding"],
             "guest_passes_outstanding": wallet_stats["guest_passes_outstanding"],
         },
-        "reservations_30d": _reservations_30d_series(reservations_by_day, last_30, today),
-        "occupancy_by_instructor": _occupancy_by_instructor(month_schedules),
+        "range": {
+            "days": days,
+            "start": period_start.isoformat(),
+            "end": today.isoformat(),
+        },
+        "reservations_30d": _reservations_series(reservations_by_day, period_start, today),
+        "occupancy_by_instructor": _occupancy_by_instructor(period_schedules),
         "plan_mix": _plan_mix(today, active_qs),
-        "demand_by_format": _demand_by_format(month_schedules),
-        "classes_vs_noshows": _classes_vs_noshows(week_start, today),
-        "schedule_vs_occupancy": _schedule_vs_occupancy(month_schedules),
+        "demand_by_format": _demand_by_format(period_schedules),
+        "classes_vs_noshows": _classes_vs_noshows(period_start, today),
+        "schedule_vs_occupancy": _schedule_vs_occupancy(period_schedules),
         "revenue_by_plan": wallet_stats["revenue_by_plan"],
-        "purchases_30d": wallet_stats["purchases_30d"],
+        "purchases_30d": wallet_stats["purchases_series"],
         "recent_purchases": wallet_stats["recent_purchases"],
     }
 
@@ -152,7 +159,7 @@ def _reservation_counts_by_day(start, end) -> dict:
     return {row["day"]: row["total"] for row in rows}
 
 
-def _reservations_30d_series(by_day, start, end) -> dict:
+def _reservations_series(by_day, start, end) -> dict:
     labels = []
     values = []
     cursor = start
@@ -377,30 +384,25 @@ def _clean_plan_name(name: str | None) -> str:
     return name
 
 
-def _wallet_commerce(today, revenue_start, last_30) -> dict:
+def _wallet_commerce(today, period_start) -> dict:
     wallets = Wallet.objects.all()
     unlimited = wallets.filter(is_unlimited_membership_active=True).count()
     class_credits = wallets.aggregate(total=Sum("class_credits"))["total"] or 0
     guest_passes = wallets.aggregate(total=Sum("guest_pass_credits"))["total"] or 0
 
-    purchases_7d_start = timezone.make_aware(datetime.combine(revenue_start, time.min))
-    purchases_7d_end = timezone.make_aware(datetime.combine(today, time.max))
-    purchases_7d = PlanPurchase.objects.filter(
-        created__gte=purchases_7d_start, created__lte=purchases_7d_end
-    ).count()
-
-    month_start = timezone.make_aware(datetime.combine(last_30, time.min))
-    month_end = purchases_7d_end
-    month_purchases = (
-        PlanPurchase.objects.filter(created__gte=month_start, created__lte=month_end)
+    period_start_dt = timezone.make_aware(datetime.combine(period_start, time.min))
+    period_end_dt = timezone.make_aware(datetime.combine(today, time.max))
+    period_purchases = (
+        PlanPurchase.objects.filter(created__gte=period_start_dt, created__lte=period_end_dt)
         .select_related("plan", "user")
         .order_by("-created")
     )
+    purchases_period = period_purchases.count()
 
     by_plan = defaultdict(lambda: {"count": 0, "revenue": 0.0})
     by_day_count = defaultdict(int)
     by_day_revenue = defaultdict(float)
-    for purchase in month_purchases:
+    for purchase in period_purchases:
         plan_name = _clean_plan_name(purchase.plan.name)
         price = float(purchase.price_paid or 0)
         by_plan[plan_name]["count"] += 1
@@ -425,7 +427,7 @@ def _wallet_commerce(today, revenue_start, last_30) -> dict:
     labels = []
     counts = []
     revenues = []
-    cursor = last_30
+    cursor = period_start
     while cursor <= today:
         labels.append(cursor.isoformat())
         counts.append(by_day_count.get(cursor, 0))
@@ -433,7 +435,7 @@ def _wallet_commerce(today, revenue_start, last_30) -> dict:
         cursor += timedelta(days=1)
 
     recent = []
-    for purchase in month_purchases[:8]:
+    for purchase in period_purchases[:8]:
         user = purchase.user
         name = f"{(user.first_name or '').strip()} {(user.last_name or '').strip()}".strip()
         recent.append(
@@ -447,11 +449,11 @@ def _wallet_commerce(today, revenue_start, last_30) -> dict:
         )
 
     return {
-        "purchases_7d": purchases_7d,
+        "purchases_period": purchases_period,
         "unlimited_wallets": unlimited,
         "class_credits_outstanding": int(class_credits),
         "guest_passes_outstanding": int(guest_passes),
         "revenue_by_plan": revenue_by_plan,
-        "purchases_30d": {"labels": labels, "counts": counts, "revenue_clp": revenues},
+        "purchases_series": {"labels": labels, "counts": counts, "revenue_clp": revenues},
         "recent_purchases": recent,
     }

--- a/apps/analytics/tests/test_dashboard_views.py
+++ b/apps/analytics/tests/test_dashboard_views.py
@@ -58,6 +58,22 @@ class TestAdminDashboardView:
         assert set(body["kpis"]["revenue_7d"]).issuperset(
             {"amount_clp", "amount_usd", "amount_mxn", "fx"}
         )
+        assert body["range"]["days"] == 30
+        assert len(body["reservations_30d"]["labels"]) == 30
+
+    def test_days_query_param_shortens_series(self, staff_client):
+        response = staff_client.get(reverse("admin-dashboard"), {"days": 7})
+        assert response.status_code == 200
+        body = response.data
+        assert body["range"]["days"] == 7
+        assert len(body["reservations_30d"]["labels"]) == 7
+        assert len(body["purchases_30d"]["labels"]) == 7
+        assert len(body["classes_vs_noshows"]["labels"]) == 7
+
+    def test_invalid_days_falls_back_to_default(self, staff_client):
+        response = staff_client.get(reverse("admin-dashboard"), {"days": 11})
+        assert response.status_code == 200
+        assert response.data["range"]["days"] == 30
 
 
 @pytest.mark.django_db

--- a/apps/analytics/views.py
+++ b/apps/analytics/views.py
@@ -2,6 +2,7 @@ from rest_framework.permissions import IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from apps.analytics.constants import DASHBOARD_ALLOWED_DAYS, DASHBOARD_DEFAULT_DAYS
 from apps.analytics.services import get_admin_dashboard
 
 
@@ -11,4 +12,14 @@ class AdminDashboardView(APIView):
     permission_classes = [IsAuthenticated, IsAdminUser]
 
     def get(self, request, *args, **kwargs):
-        return Response(get_admin_dashboard())
+        return Response(get_admin_dashboard(days=_parse_days(request.query_params.get("days"))))
+
+
+def _parse_days(raw) -> int:
+    try:
+        days = int(raw)
+    except (TypeError, ValueError):
+        return DASHBOARD_DEFAULT_DAYS
+    if days not in DASHBOARD_ALLOWED_DAYS:
+        return DASHBOARD_DEFAULT_DAYS
+    return days

--- a/apps/users/apps.py
+++ b/apps/users/apps.py
@@ -4,3 +4,15 @@ from django.apps import AppConfig
 class UsersConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "apps.users"
+
+    def ready(self):
+        from django.db.backends.signals import connection_created
+
+        def enable_sqlite_wal(sender, connection, **kwargs):
+            if connection.vendor != "sqlite":
+                return
+            with connection.cursor() as cursor:
+                cursor.execute("PRAGMA journal_mode=WAL;")
+                cursor.execute("PRAGMA busy_timeout=20000;")
+
+        connection_created.connect(enable_sqlite_wal, dispatch_uid="users_sqlite_wal")

--- a/apps/users/authentication.py
+++ b/apps/users/authentication.py
@@ -1,0 +1,43 @@
+"""Token authentication that does not write SQLite on every request."""
+
+from django.db import transaction
+from django.utils import timezone
+from drf_expiring_token.authentication import (
+    ExpiringTokenAuthentication as BaseExpiringTokenAuthentication,
+)
+from drf_expiring_token.authentication import token_expire_handler
+from drf_expiring_token.models import ExpiringToken
+from drf_expiring_token.settings import custom_settings
+from rest_framework.exceptions import AuthenticationFailed
+
+
+class ExpiringTokenAuthentication(BaseExpiringTokenAuthentication):
+    """Sliding expiry without a `token.save()` on each API call.
+
+    The upstream class updates `expires` on every authenticate. Admin pages
+    fire parallel GETs (Horarios loads instructors, rooms, and schedules at
+    once). On SQLite that write contention raises OperationalError
+    "database is locked" and the client shows HTTP 500.
+    """
+
+    @transaction.atomic(savepoint=False)
+    def authenticate_credentials(self, key):
+        try:
+            token = ExpiringToken.objects.select_related("user").get(key=key)
+        except ExpiringToken.DoesNotExist:
+            raise AuthenticationFailed("Invalid Token")
+
+        if not token.user.is_active:
+            raise AuthenticationFailed("User is not active")
+
+        is_expired, token = token_expire_handler(token)
+        if is_expired:
+            raise AuthenticationFailed("The Token is expired")
+
+        duration = custom_settings.EXPIRING_TOKEN_DURATION
+        remaining = token.expires - timezone.now()
+        if remaining <= duration / 2:
+            token.expires = timezone.now() + duration
+            token.save(update_fields=["expires"])
+
+        return token.user, token

--- a/apps/users/tests/test_authentication.py
+++ b/apps/users/tests/test_authentication.py
@@ -1,0 +1,69 @@
+from datetime import timedelta
+from unittest.mock import patch
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from django.utils import timezone
+from drf_expiring_token.models import ExpiringToken
+from drf_expiring_token.settings import custom_settings
+from rest_framework.exceptions import AuthenticationFailed
+
+from apps.users.authentication import ExpiringTokenAuthentication
+
+User = get_user_model()
+
+
+@pytest.fixture
+def staff_user(db):
+    return User.objects.create_user(
+        username="staff",
+        email="staff@example.com",
+        password="testpass123",
+        is_staff=True,
+    )
+
+
+@pytest.mark.django_db
+class TestExpiringTokenAuthentication:
+    def test_fresh_token_does_not_write(self, staff_user):
+        token = ExpiringToken.objects.create(user=staff_user)
+        auth = ExpiringTokenAuthentication()
+
+        with patch.object(ExpiringToken, "save") as save:
+            user, returned = auth.authenticate_credentials(token.key)
+
+        assert user == staff_user
+        assert returned.key == token.key
+        save.assert_not_called()
+
+    def test_extends_expiry_when_halfway_elapsed(self, staff_user):
+        token = ExpiringToken.objects.create(user=staff_user)
+        ExpiringToken.objects.filter(pk=token.pk).update(
+            expires=timezone.now() + (custom_settings.EXPIRING_TOKEN_DURATION / 2),
+        )
+        auth = ExpiringTokenAuthentication()
+
+        auth.authenticate_credentials(token.key)
+
+        token.refresh_from_db()
+        assert token.expires > timezone.now() + (custom_settings.EXPIRING_TOKEN_DURATION / 2)
+
+    def test_expired_token_is_rejected(self, staff_user):
+        token = ExpiringToken.objects.create(user=staff_user)
+        ExpiringToken.objects.filter(pk=token.pk).update(
+            expires=timezone.now() - timedelta(seconds=1),
+        )
+        auth = ExpiringTokenAuthentication()
+
+        with pytest.raises(AuthenticationFailed):
+            auth.authenticate_credentials(token.key)
+
+    def test_admin_instructor_list_succeeds_for_staff(self, api_client, staff_user):
+        token = ExpiringToken.objects.create(user=staff_user)
+        api_client.credentials(HTTP_AUTHORIZATION=f"Token {token.key}")
+
+        response = api_client.get(reverse("admin-instructors"))
+
+        assert response.status_code == 200
+        assert isinstance(response.data, list)


### PR DESCRIPTION
## Summary
- Stop writing the auth token on every request (that locked SQLite when Horarios fired parallel GETs and returned 500).
- Wait on the SQLite lock and enable WAL.
- Dashboard analytics accept `?days=7|14|30|60|90` (default 30); demo seed covers 90 days.

## Test plan
- Hit `/api/instructors/admin/`, rooms, and schedules in parallel with a staff token: all 200.
- `GET /api/analytics/admin/dashboard/?days=7` returns `range.days == 7` and 7-point series.


Made with [Cursor](https://cursor.com)