### PR TITLE
feat(analytics): expand member stats for the rider dashboard

### DIFF
--- a/apps/analytics/member_stats.py
+++ b/apps/analytics/member_stats.py
@@ -1,4 +1,4 @@
-"""Member-facing activity stats for the authenticated profile page."""
+"""Member-facing activity stats for the authenticated rider dashboard."""
 
 from collections import Counter
 from datetime import date, timedelta
@@ -17,6 +17,10 @@ from apps.wallets.models import PlanPurchase, Wallet
 
 MONTHS_WINDOW = 6
 STREAK_CHART_WEEKS = 4
+HOUR_RANGE = range(6, 22)
+TOP_COACHES = 5
+TOP_CLASSES = 6
+TOP_SPOTS = 5
 CONSUMED_STATUSES = (
     RESERVATION_STATUS_RESERVED,
     RESERVATION_STATUS_ATTENDED,
@@ -36,6 +40,8 @@ def get_member_stats(user, *, now=None) -> dict:
     is_unlimited = bool(plan and wallet and wallet.is_unlimited_membership_active) or (
         plan is not None and plan.classes_included is None
     )
+    class_credits = int(wallet.class_credits) if wallet else 0
+    guest_pass_credits = int(wallet.guest_pass_credits) if wallet else 0
 
     empty = _empty_payload(
         month_starts=month_starts,
@@ -44,6 +50,8 @@ def get_member_stats(user, *, now=None) -> dict:
         plan_name=plan.name if plan else None,
         classes_included=None if is_unlimited or plan is None else plan.classes_included,
         is_unlimited=bool(is_unlimited and plan is not None),
+        class_credits=class_credits,
+        guest_pass_credits=guest_pass_credits,
     )
     if member is None:
         return empty
@@ -59,19 +67,26 @@ def get_member_stats(user, *, now=None) -> dict:
 
     attended_local = []
     consumed_this_month = 0
+    missed_count = 0
+    upcoming_count = 0
     for reservation in reservations:
         schedule = reservation.schedule
         if schedule is None or schedule.start_time is None:
             continue
-        local_date = timezone.localtime(schedule.start_time).date()
+        local_dt = timezone.localtime(schedule.start_time)
+        local_date = local_dt.date()
         if (
             reservation.status in CONSUMED_STATUSES
             and local_date.year == today.year
             and local_date.month == today.month
         ):
             consumed_this_month += 1
+        if reservation.status == RESERVATION_STATUS_MISSED:
+            missed_count += 1
+        if reservation.status == RESERVATION_STATUS_RESERVED and schedule.start_time >= now:
+            upcoming_count += 1
         if reservation.status == RESERVATION_STATUS_ATTENDED:
-            attended_local.append((reservation, local_date, schedule))
+            attended_local.append((reservation, local_dt, schedule))
 
     monthly_classes = [0] * MONTHS_WINDOW
     monthly_ride_minutes = [0] * MONTHS_WINDOW
@@ -79,13 +94,20 @@ def get_member_stats(user, *, now=None) -> dict:
     instructor_counts = Counter()
     instructor_last = {}
     studio_counts = Counter()
+    title_counts = Counter()
+    spot_counts = Counter()
+    hour_counts = [0] * 24
+    weekday_counts = [0] * 7
     last_visit = None
     total_ride_minutes = 0
     attended_week_starts = set()
+    classes_attended_total = 0
 
-    for reservation, local_date, schedule in attended_local:
+    for reservation, local_dt, schedule in attended_local:
+        local_date = local_dt.date()
         duration = int(schedule.duration_minutes or 0)
         total_ride_minutes += duration
+        classes_attended_total += 1
         if last_visit is None or local_date > last_visit:
             last_visit = local_date
 
@@ -96,6 +118,14 @@ def get_member_stats(user, *, now=None) -> dict:
             monthly_ride_minutes[idx] += duration
 
         attended_week_starts.add(_iso_week_start(local_date))
+        hour_counts[local_dt.hour] += 1
+        weekday_counts[local_date.weekday()] += 1
+
+        title = (schedule.title or "").strip() or "Clase"
+        title_counts[title] += 1
+
+        if reservation.spot:
+            spot_counts[int(reservation.spot)] += 1
 
         instructor = schedule.instructor
         if instructor is not None:
@@ -109,18 +139,31 @@ def get_member_stats(user, *, now=None) -> dict:
             studio_counts[studio.id] += 1
 
     weekly_streak = [start in attended_week_starts for start in week_starts]
-
     favorite = _favorite_instructor(instructor_counts, instructor_last, attended_local)
     preferred_studio = _preferred_studio_name(studio_counts, attended_local)
+    completed_window = sum(monthly_classes)
+    weeks_in_window = max(1, (today - month_starts[0]).days / 7)
+    avg_per_week = round(completed_window / weeks_in_window, 1) if completed_window else 0
+    attendance_rate = None
+    settled = classes_attended_total + missed_count
+    if settled:
+        attendance_rate = round(100.0 * classes_attended_total / settled, 1)
 
     return {
         "plan_name": plan.name if plan else None,
         "member_since": _member_since(member, user),
         "preferred_studio": preferred_studio,
-        "classes_completed": sum(monthly_classes),
+        "classes_completed": completed_window,
+        "classes_attended_total": classes_attended_total,
+        "classes_missed": missed_count,
+        "classes_upcoming": upcoming_count,
         "classes_this_month": consumed_this_month,
         "classes_included": None if is_unlimited or plan is None else plan.classes_included,
         "is_unlimited": bool(is_unlimited and plan is not None),
+        "class_credits": class_credits,
+        "guest_pass_credits": guest_pass_credits,
+        "avg_classes_per_week": avg_per_week,
+        "attendance_rate": attendance_rate,
         "current_streak_weeks": _current_streak_weeks(today, attended_week_starts),
         "last_visit": last_visit.isoformat() if last_visit else None,
         "total_ride_minutes": total_ride_minutes,
@@ -129,20 +172,42 @@ def get_member_stats(user, *, now=None) -> dict:
         "weekly_streak": weekly_streak,
         "monthly_ride_minutes": monthly_ride_minutes,
         "favorite_instructor": favorite,
+        "top_instructors": _top_instructors(instructor_counts, attended_local),
+        "favorite_classes": _top_named(title_counts, TOP_CLASSES),
+        "preferred_hours": _preferred_hours(hour_counts),
+        "weekday_classes": weekday_counts,
+        "time_of_day": _time_of_day(hour_counts),
+        "favorite_spots": _favorite_spots(spot_counts),
+        "rider_persona": _rider_persona(weekday_counts, hour_counts),
     }
 
 
 def _empty_payload(
-    *, month_starts, week_starts, member_since, plan_name, classes_included, is_unlimited
+    *,
+    month_starts,
+    week_starts,
+    member_since,
+    plan_name,
+    classes_included,
+    is_unlimited,
+    class_credits,
+    guest_pass_credits,
 ):
     return {
         "plan_name": plan_name,
         "member_since": member_since,
         "preferred_studio": None,
         "classes_completed": 0,
+        "classes_attended_total": 0,
+        "classes_missed": 0,
+        "classes_upcoming": 0,
         "classes_this_month": 0,
         "classes_included": classes_included,
         "is_unlimited": is_unlimited,
+        "class_credits": class_credits,
+        "guest_pass_credits": guest_pass_credits,
+        "avg_classes_per_week": 0,
+        "attendance_rate": None,
         "current_streak_weeks": 0,
         "last_visit": None,
         "total_ride_minutes": 0,
@@ -151,6 +216,13 @@ def _empty_payload(
         "weekly_streak": [False] * len(week_starts),
         "monthly_ride_minutes": [0] * MONTHS_WINDOW,
         "favorite_instructor": None,
+        "top_instructors": [],
+        "favorite_classes": [],
+        "preferred_hours": _preferred_hours([0] * 24),
+        "weekday_classes": [0] * 7,
+        "time_of_day": _time_of_day([0] * 24),
+        "favorite_spots": [],
+        "rider_persona": None,
     }
 
 
@@ -209,21 +281,7 @@ def _current_streak_weeks(today: date, attended_week_starts: set) -> int:
     return streak
 
 
-def _favorite_instructor(counts: Counter, last_dates: dict, attended_local) -> dict | None:
-    if not counts:
-        return None
-    max_count = max(counts.values())
-    tied_ids = [instructor_id for instructor_id, count in counts.items() if count == max_count]
-    favorite_id = max(tied_ids, key=lambda instructor_id: last_dates.get(instructor_id) or date.min)
-
-    instructor = None
-    for reservation, _local_date, schedule in attended_local:
-        if schedule.instructor_id == favorite_id:
-            instructor = schedule.instructor
-            break
-    if instructor is None:
-        return None
-
+def _instructor_payload(instructor, classes_count: int) -> dict:
     user = instructor.user
     return {
         "id": str(instructor.id),
@@ -232,15 +290,95 @@ def _favorite_instructor(counts: Counter, last_dates: dict, attended_local) -> d
         "tagline": instructor.tagline or "",
         "instagram_username": instructor.instagram_username or "",
         "profile_image": _profile_image_url(instructor.profile_image),
+        "classes": classes_count,
     }
+
+
+def _favorite_instructor(counts: Counter, last_dates: dict, attended_local) -> dict | None:
+    if not counts:
+        return None
+    max_count = max(counts.values())
+    tied_ids = [instructor_id for instructor_id, count in counts.items() if count == max_count]
+    favorite_id = max(tied_ids, key=lambda instructor_id: last_dates.get(instructor_id) or date.min)
+
+    instructor = None
+    for _reservation, _local_dt, schedule in attended_local:
+        if schedule.instructor_id == favorite_id:
+            instructor = schedule.instructor
+            break
+    if instructor is None:
+        return None
+    return _instructor_payload(instructor, counts[favorite_id])
+
+
+def _top_instructors(counts: Counter, attended_local) -> list[dict]:
+    by_id = {}
+    for _reservation, _local_dt, schedule in attended_local:
+        instructor = schedule.instructor
+        if instructor is not None and instructor.id not in by_id:
+            by_id[instructor.id] = instructor
+    rows = []
+    for instructor_id, count in counts.most_common(TOP_COACHES):
+        instructor = by_id.get(instructor_id)
+        if instructor is not None:
+            rows.append(_instructor_payload(instructor, count))
+    return rows
 
 
 def _preferred_studio_name(counts: Counter, attended_local) -> str | None:
     if not counts:
         return None
     studio_id = counts.most_common(1)[0][0]
-    for _reservation, _local_date, schedule in attended_local:
+    for _reservation, _local_dt, schedule in attended_local:
         studio = getattr(schedule.room, "studio", None) if schedule.room_id else None
         if studio is not None and studio.id == studio_id:
             return studio.name
     return None
+
+
+def _top_named(counts: Counter, limit: int) -> list[dict]:
+    return [{"name": name, "count": count} for name, count in counts.most_common(limit)]
+
+
+def _preferred_hours(hour_counts: list[int]) -> dict:
+    hours = list(HOUR_RANGE)
+    extra = [hour for hour, count in enumerate(hour_counts) if count and hour not in hours]
+    hours = sorted(set(hours).union(extra))
+    return {
+        "labels": [f"{hour:02d}:00" for hour in hours],
+        "values": [hour_counts[hour] for hour in hours],
+    }
+
+
+def _time_of_day(hour_counts: list[int]) -> dict:
+    morning = sum(hour_counts[hour] for hour in range(5, 12))
+    midday = sum(hour_counts[hour] for hour in range(12, 17))
+    evening = sum(hour_counts[hour] for hour in range(17, 22))
+    night = sum(hour_counts[hour] for hour in list(range(0, 5)) + list(range(22, 24)))
+    return {
+        "morning": morning,
+        "midday": midday,
+        "evening": evening,
+        "night": night,
+    }
+
+
+def _favorite_spots(counts: Counter) -> list[dict]:
+    return [{"spot": spot, "count": count} for spot, count in counts.most_common(TOP_SPOTS)]
+
+
+def _rider_persona(weekday_counts: list[int], hour_counts: list[int]) -> dict | None:
+    total = sum(hour_counts)
+    if total == 0:
+        return None
+    weekend = weekday_counts[5] + weekday_counts[6]
+    if weekend / total >= 0.5:
+        return {"id": "weekend", "label": "Guerrero de fin de semana"}
+    peak_hour = hour_counts.index(max(hour_counts))
+    if peak_hour < 9:
+        return {"id": "early", "label": "Madrugador"}
+    if peak_hour < 12:
+        return {"id": "morning", "label": "Ritmo matinal"}
+    if peak_hour < 17:
+        return {"id": "midday", "label": "Mediodía"}
+    return {"id": "afterwork", "label": "After work"}

--- a/apps/analytics/tests/test_member_stats.py
+++ b/apps/analytics/tests/test_member_stats.py
@@ -30,12 +30,13 @@ def _schedule(*, instructor, room, start, duration=45, title="RIDE 45"):
     )
 
 
-def _attend(member, schedule, status=member_constants.RESERVATION_STATUS_ATTENDED):
+def _attend(member, schedule, status=member_constants.RESERVATION_STATUS_ATTENDED, spot=None):
     return baker.make(
         "members.Reservation",
         member=member,
         schedule=schedule,
         status=status,
+        spot=spot,
     )
 
 
@@ -79,7 +80,12 @@ def test_member_stats_aggregates_attendance_plan_and_favorite():
     room = baker.make("studios.Room", studio=studio, capacity=20, is_active=True)
 
     plan = baker.make("plans.Plan", name="Starter 8", classes_included=8, price=59000)
-    Wallet.objects.create(user=member_user, is_unlimited_membership_active=False)
+    Wallet.objects.create(
+        user=member_user,
+        is_unlimited_membership_active=False,
+        class_credits=3,
+        guest_pass_credits=1,
+    )
     PlanPurchase.objects.create(
         user=member_user,
         plan=plan,
@@ -92,22 +98,40 @@ def test_member_stats_aggregates_attendance_plan_and_favorite():
     for weeks_ago in (1, 2, 3):
         day = last_monday - timedelta(weeks=weeks_ago)
         start = datetime(day.year, day.month, day.day, 18, 0, tzinfo=dt_timezone.utc)
-        _attend(member, _schedule(instructor=favorite, room=room, start=start))
+        _attend(
+            member,
+            _schedule(instructor=favorite, room=room, start=start, title="Power Ride"),
+            spot=7,
+        )
 
     extra_day = last_monday - timedelta(weeks=1, days=1)
     extra_start = datetime(
         extra_day.year, extra_day.month, extra_day.day, 10, 0, tzinfo=dt_timezone.utc
     )
-    _attend(member, _schedule(instructor=favorite, room=room, start=extra_start, duration=50))
+    _attend(
+        member,
+        _schedule(
+            instructor=favorite, room=room, start=extra_start, duration=50, title="Power Ride"
+        ),
+        spot=7,
+    )
 
     other_day = last_monday - timedelta(weeks=1, days=2)
     other_start = datetime(
         other_day.year, other_day.month, other_day.day, 12, 0, tzinfo=dt_timezone.utc
     )
-    _attend(member, _schedule(instructor=other, room=room, start=other_start))
+    _attend(
+        member,
+        _schedule(instructor=other, room=room, start=other_start, title="Rhythm Ride"),
+        spot=12,
+    )
 
     july = datetime(2026, 7, 2, 19, 0, tzinfo=dt_timezone.utc)
-    _attend(member, _schedule(instructor=favorite, room=room, start=july, duration=45))
+    _attend(
+        member,
+        _schedule(instructor=favorite, room=room, start=july, duration=45, title="Power Ride"),
+        spot=7,
+    )
 
     this_month_reserved = datetime(2026, 8, 18, 19, 0, tzinfo=dt_timezone.utc)
     _attend(
@@ -131,3 +155,13 @@ def test_member_stats_aggregates_attendance_plan_and_favorite():
     assert payload["classes_completed"] == sum(payload["monthly_classes"])
     assert payload["total_ride_minutes"] > 0
     assert payload["monthly_labels"][-1] == "2026-08"
+    assert payload["class_credits"] == 3
+    assert payload["guest_pass_credits"] == 1
+    assert payload["top_instructors"][0]["first_name"] == "Tomás"
+    assert payload["top_instructors"][0]["classes"] >= payload["top_instructors"][1]["classes"]
+    assert payload["favorite_classes"][0]["name"] == "Power Ride"
+    assert payload["favorite_spots"][0]["spot"] == 7
+    assert sum(payload["preferred_hours"]["values"]) == payload["classes_attended_total"]
+    assert sum(payload["weekday_classes"]) == payload["classes_attended_total"]
+    assert payload["rider_persona"] is not None
+    assert payload["attendance_rate"] == 100.0

--- a/apps/analytics/views.py
+++ b/apps/analytics/views.py
@@ -8,7 +8,7 @@ from apps.analytics.services import get_admin_dashboard
 
 
 class MemberStatsView(APIView):
-    """Activity stats for the authenticated member profile."""
+    """Activity dashboard stats for the authenticated member."""
 
     permission_classes = [IsAuthenticated]
 


### PR DESCRIPTION
## Motivation
The rider dashboard needs richer activity data than the original profile widgets: preferred hours, favorite classes, top coaches, and wallet remaining credits.

## Implementation
`GET /api/analytics/me/` now also returns:
- `top_instructors`, `favorite_classes`, `preferred_hours`
- `weekday_classes`, `time_of_day`, `favorite_spots`, `rider_persona`
- wallet `class_credits` / `guest_pass_credits`
- attendance mix (`classes_attended_total`, `classes_missed`, `classes_upcoming`, `attendance_rate`)

Existing profile fields are unchanged.

## Test Plan
`.venv/bin/python -m pytest apps/analytics/tests/test_member_stats.py -q`

## Deploy
API additive. Safe to revert.


Made with [Cursor](https://cursor.com)