### PR TITLE
feat(analytics): seed member dashboard data through 31 October

### DIFF
--- a/apps/analytics/management/commands/seed_dashboard_demo.py
+++ b/apps/analytics/management/commands/seed_dashboard_demo.py
@@ -1,14 +1,21 @@
-"""Seed a realistic PulseFit studio so the admin dashboard has charts to show.
+"""Seed a realistic PulseFit studio so dashboards have charts to show.
 
 Idempotent: demo rows are tagged with the `demo.dash.` username prefix.
 Pass --reset to wipe previous demo rows and recreate them.
+
+Schedules cover six calendar months of history through 31 October so the
+admin dashboard and member "Mis estadísticas" page have past and upcoming
+classes. Running the command again fills any missing days without duplicating
+rows, backfills bike spots, and attaches a ride history to real members.
 """
 
-from datetime import datetime, timedelta
+from collections import defaultdict
+from datetime import date, datetime, timedelta
 from random import Random
 
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
+from django.db.models import Count
 from django.utils import timezone
 
 from apps.analytics.constants import (
@@ -53,16 +60,59 @@ FORMAT_WEIGHTS = {
     "SCULPT": 0.16,
     "REFORMER": 0.16,
 }
+DEMO_CLASS_DESCRIPTION = "Clase demo dashboard"
+DEMO_RIDER_USERNAME = f"{DEMO_USERNAME_PREFIX}rider"
+DEMO_RESERVATION_NOTE = "demo.member-stats"
+STORY_SPOTS = (7, 7, 7, 8, 4)
+CLASSES_PER_WEEK = 3
+
+
+def demo_horizon_end(today: date) -> date:
+    """Cover remaining season through 31 October."""
+    end_day = date(today.year, 10, 31)
+    if today > end_day:
+        end_day = date(today.year + 1, 10, 31)
+    return end_day
+
+
+def demo_history_start(today: date) -> date:
+    """First day of the month five months before today (six calendar months)."""
+    year = today.year
+    month = today.month - 5
+    while month <= 0:
+        month += 12
+        year -= 1
+    return date(year, month, 1)
+
+
+def _iso_week_start(day: date) -> date:
+    return day - timedelta(days=day.weekday())
 
 
 class Command(BaseCommand):
-    help = "Create demo schedules, reservations and purchases for the admin dashboard."
+    help = (
+        "Create demo schedules, reservations and purchases through 31 October "
+        "for the admin and member dashboards."
+    )
 
     def add_arguments(self, parser):
         parser.add_argument(
             "--reset",
             action="store_true",
             help="Delete previous demo.dash.* rows before seeding.",
+        )
+        parser.add_argument(
+            "--until",
+            help="Last calendar day to seed (YYYY-MM-DD). Defaults to 31 October.",
+        )
+        parser.add_argument(
+            "--history-days",
+            type=int,
+            help="How many days of history to include (default: six calendar months).",
+        )
+        parser.add_argument(
+            "--as-of",
+            help="Pretend today is this date (YYYY-MM-DD). Defaults to the local date.",
         )
 
     def handle(self, *args, **options):
@@ -71,27 +121,50 @@ class Command(BaseCommand):
             self._wipe()
             self.stdout.write(self.style.WARNING("Removed previous dashboard demo data."))
 
-        if User.objects.filter(username__startswith=DEMO_USERNAME_PREFIX).exists():
-            self.stdout.write(
-                self.style.SUCCESS("Dashboard demo data already exists. Use --reset to recreate.")
-            )
-            return
+        today = date.fromisoformat(options["as_of"]) if options["as_of"] else timezone.localdate()
+        end_day = (
+            date.fromisoformat(options["until"]) if options["until"] else demo_horizon_end(today)
+        )
+        if options["history_days"]:
+            start_day = today - timedelta(days=max(1, options["history_days"]) - 1)
+        else:
+            start_day = demo_history_start(today)
+        if start_day > end_day:
+            start_day = end_day
 
-        today = timezone.localdate()
         studio, room = self._studio()
         instructors = self._instructors()
         plans = self._plans()
         members = self._members(rng, plans, today)
-        self._schedules_and_reservations(rng, instructors, room, members, today)
-        self._recent_purchases(rng, members, plans, today)
+        new_schedules = self._ensure_schedules(rng, instructors, room, start_day, end_day, today)
+        if new_schedules:
+            self._fill_occupancy(rng, room, members, new_schedules, today)
+        self._backfill_spots(room)
+        if not PlanPurchase.objects.filter(
+            user__username__startswith=DEMO_USERNAME_PREFIX
+        ).exists():
+            self._recent_purchases(rng, members, plans, today)
 
+        rider = self._showcase_rider(plans, today)
+        attached = self._attach_rider_stories(room, [rider, *self._real_members()], today)
+        schedules = Schedule.objects.filter(description=DEMO_CLASS_DESCRIPTION).count()
+        last = (
+            Schedule.objects.filter(description=DEMO_CLASS_DESCRIPTION)
+            .order_by("-start_time")
+            .values_list("start_time", flat=True)
+            .first()
+        )
+        last_label = timezone.localtime(last).date().isoformat() if last else "—"
         self.stdout.write(
             self.style.SUCCESS(
-                f"Seeded dashboard demo: {len(members)} socios, {len(instructors)} instructores, sala {room.name}."
+                f"Seeded dashboard demo through {last_label}: {len(members)} socios demo, "
+                f"{schedules} clases, {attached} reservas de historia de socio "
+                f"(incluye {DEMO_RIDER_USERNAME})."
             )
         )
 
     def _wipe(self):
+        Reservation.objects.filter(notes=DEMO_RESERVATION_NOTE).delete()
         demo_users = User.objects.filter(username__startswith=DEMO_USERNAME_PREFIX)
         Reservation.objects.filter(member__user__in=demo_users).delete()
         Schedule.objects.filter(instructor__user__in=demo_users).delete()
@@ -153,6 +226,14 @@ class Command(BaseCommand):
         return plans
 
     def _members(self, rng, plans, today):
+        existing = list(
+            Member.objects.filter(user__username__startswith=f"{DEMO_USERNAME_PREFIX}member.")
+            .select_related("user")
+            .order_by("user__username")
+        )
+        if existing:
+            return existing
+
         members = []
         mix = [plans[0]] * 18 + [plans[1]] * 12 + [plans[2]] * 8 + [plans[3]] * 4 + [plans[4]] * 6
         rng.shuffle(mix)
@@ -189,7 +270,13 @@ class Command(BaseCommand):
                 user.set_password("demo1234")
                 user.save()
             member, _ = Member.objects.get_or_create(user=user)
-            wallet, _ = Wallet.objects.get_or_create(user=user)
+            self._activate_wallet(user, plan, today, rng, index)
+            members.append(member)
+        return members
+
+    def _activate_wallet(self, user, plan, today, rng, index):
+        wallet, _ = Wallet.objects.get_or_create(user=user)
+        if not PlanPurchase.objects.filter(user=user, plan=plan).exists():
             activated = today - timedelta(days=rng.randint(5, 40))
             purchase = PlanPurchase.objects.create(
                 user=user,
@@ -200,21 +287,55 @@ class Command(BaseCommand):
             PlanPurchase.objects.filter(pk=purchase.pk).update(
                 created=timezone.make_aware(datetime.combine(activated, datetime.min.time()))
             )
-            wallet.active_membership_end_date = today + timedelta(days=rng.randint(5, 25))
-            wallet.is_unlimited_membership_active = "Ilimitado" in plan.name
-            wallet.class_credits = (
-                0 if wallet.is_unlimited_membership_active else (plan.classes_included or 12)
+        wallet.active_membership_end_date = today + timedelta(days=rng.randint(70, 110))
+        wallet.is_unlimited_membership_active = "Ilimitado" in plan.name
+        wallet.class_credits = (
+            0 if wallet.is_unlimited_membership_active else (plan.classes_included or 12)
+        )
+        wallet.guest_pass_credits = (
+            2 if "Premium" in plan.name or "Ilimitado" in plan.name else rng.randint(0, 1)
+        )
+        wallet.is_priority_booker = "Ilimitado" in plan.name or (
+            "Premium" in plan.name and index % 2 == 0
+        )
+        wallet.can_freeze_membership = "Ilimitado" in plan.name
+        wallet.save()
+
+    def _showcase_rider(self, plans, today):
+        smart = next((plan for plan in plans if "Smart 8" in plan.name), plans[2])
+        user, created = User.objects.get_or_create(
+            username=DEMO_RIDER_USERNAME,
+            defaults={
+                "email": f"rider@{DEMO_EMAIL_DOMAIN}",
+                "first_name": "Alex",
+                "last_name": "Rider",
+            },
+        )
+        if created:
+            user.set_password("demo1234")
+            user.save()
+        member, _ = Member.objects.get_or_create(user=user)
+        wallet, _ = Wallet.objects.get_or_create(user=user)
+        if not PlanPurchase.objects.filter(user=user, plan=smart).exists():
+            PlanPurchase.objects.create(
+                user=user,
+                plan=smart,
+                price_paid=smart.price,
+                activated_since=today - timedelta(days=20),
             )
-            wallet.guest_pass_credits = (
-                2 if "Premium" in plan.name or "Ilimitado" in plan.name else rng.randint(0, 1)
-            )
-            wallet.is_priority_booker = "Ilimitado" in plan.name or (
-                "Premium" in plan.name and index % 2 == 0
-            )
-            wallet.can_freeze_membership = "Ilimitado" in plan.name
-            wallet.save()
-            members.append(member)
-        return members
+        wallet.active_membership_end_date = date(today.year, 10, 31)
+        wallet.is_unlimited_membership_active = False
+        wallet.class_credits = 5
+        wallet.guest_pass_credits = 2
+        wallet.save()
+        return member
+
+    def _real_members(self):
+        return list(
+            Member.objects.filter(is_removed=False)
+            .exclude(user__username__startswith=DEMO_USERNAME_PREFIX)
+            .select_related("user")
+        )
 
     def _pick_format(self, rng):
         roll = rng.random()
@@ -225,23 +346,31 @@ class Command(BaseCommand):
                 return fmt
         return CLASS_FORMATS[0]
 
-    def _schedules_and_reservations(self, rng, instructors, room, members, today):
+    def _ensure_schedules(self, rng, instructors, room, start_day, end_day, today):
+        existing = {
+            timezone.localtime(start).replace(minute=0, second=0, microsecond=0)
+            for start in Schedule.objects.filter(
+                room=room, description=DEMO_CLASS_DESCRIPTION
+            ).values_list("start_time", flat=True)
+        }
         schedules = []
-        start_day = today - timedelta(days=89)
-        for offset in range(90):
+        total_days = (end_day - start_day).days + 1
+        for offset in range(total_days):
             day = start_day + timedelta(days=offset)
             hours = CLASS_HOURS if day.weekday() < 5 else [9, 10, 18, 19]
             for hour in hours:
+                start_time = timezone.make_aware(datetime(day.year, day.month, day.day, hour, 0))
+                if start_time in existing:
+                    continue
                 fmt = self._pick_format(rng)
                 instructor = instructors[rng.randrange(len(instructors))]
-                start_time = timezone.make_aware(datetime(day.year, day.month, day.day, hour, 0))
                 status = schedule_constants.SCHEDULE_STATUS_SCHEDULED
                 if day < today:
                     status = schedule_constants.SCHEDULE_STATUS_COMPLETED
                 schedules.append(
                     Schedule(
                         title=f"{fmt} 45",
-                        description="Clase demo dashboard",
+                        description=DEMO_CLASS_DESCRIPTION,
                         instructor=instructor,
                         start_time=start_time,
                         duration_minutes=45,
@@ -249,13 +378,22 @@ class Command(BaseCommand):
                         status=status,
                     )
                 )
-        Schedule.objects.bulk_create(schedules)
-        created = list(
-            Schedule.objects.filter(description="Clase demo dashboard").order_by("start_time")
+        if schedules:
+            Schedule.objects.bulk_create(schedules, batch_size=500)
+        created_starts = {item.start_time for item in schedules}
+        if not created_starts:
+            return []
+        return list(
+            Schedule.objects.filter(
+                description=DEMO_CLASS_DESCRIPTION, start_time__in=created_starts
+            )
         )
 
+    def _fill_occupancy(self, rng, room, members, schedules, today):
+        if not members:
+            return
         reservations = []
-        for schedule in created:
+        for schedule in schedules:
             hour = timezone.localtime(schedule.start_time).hour
             base = 0.78
             if hour in (7, 18, 19):
@@ -265,15 +403,190 @@ class Command(BaseCommand):
             occupied = max(
                 8, min(room.capacity, int(room.capacity * (base + rng.uniform(-0.08, 0.08))))
             )
+            occupied = min(occupied, len(members), room.capacity)
             chosen = rng.sample(members, k=occupied)
-            for member in chosen:
+            spots = rng.sample(range(1, room.capacity + 1), k=occupied)
+            local_day = timezone.localtime(schedule.start_time).date()
+            for member, spot in zip(chosen, spots):
                 status = member_constants.RESERVATION_STATUS_ATTENDED
-                if schedule.start_time.date() >= today:
+                if local_day >= today:
                     status = member_constants.RESERVATION_STATUS_RESERVED
                 elif rng.random() < 0.09:
                     status = member_constants.RESERVATION_STATUS_MISSED
-                reservations.append(Reservation(member=member, schedule=schedule, status=status))
+                reservations.append(
+                    Reservation(
+                        member=member,
+                        schedule=schedule,
+                        status=status,
+                        spot=spot,
+                    )
+                )
         Reservation.objects.bulk_create(reservations, batch_size=500)
+
+    def _backfill_spots(self, room):
+        taken_by_schedule = defaultdict(set)
+        open_by_schedule = defaultdict(list)
+        qs = Reservation.objects.filter(schedule__room=room).only("id", "schedule_id", "spot")
+        for reservation in qs.iterator():
+            if reservation.spot:
+                taken_by_schedule[reservation.schedule_id].add(reservation.spot)
+            else:
+                open_by_schedule[reservation.schedule_id].append(reservation)
+        if not open_by_schedule:
+            return
+        updates = []
+        for schedule_id, rows in open_by_schedule.items():
+            taken = taken_by_schedule[schedule_id]
+            available = [spot for spot in range(1, room.capacity + 1) if spot not in taken]
+            for reservation, spot in zip(rows, available):
+                reservation.spot = spot
+                updates.append(reservation)
+        if updates:
+            Reservation.objects.bulk_update(updates, ["spot"], batch_size=500)
+
+    def _attach_rider_stories(self, room, members, today):
+        members = [member for member in members if member is not None]
+        if not members:
+            return 0
+        schedules = list(
+            Schedule.objects.filter(description=DEMO_CLASS_DESCRIPTION, room=room)
+            .select_related("instructor__user")
+            .order_by("start_time")
+        )
+        if not schedules:
+            return 0
+
+        occupancy = {
+            str(row["schedule_id"]): row["total"]
+            for row in (
+                Reservation.objects.filter(schedule__in=schedules)
+                .exclude(status=member_constants.RESERVATION_STATUS_CANCELLED)
+                .values("schedule_id")
+                .annotate(total=Count("id"))
+            )
+        }
+        spots_taken = defaultdict(set)
+        already = defaultdict(set)
+        for schedule_id, member_id, spot in Reservation.objects.filter(
+            schedule__in=schedules
+        ).values_list("schedule_id", "member_id", "spot"):
+            already[str(schedule_id)].add(str(member_id))
+            if spot:
+                spots_taken[str(schedule_id)].add(spot)
+
+        favorite_id = schedules[0].instructor_id
+        for schedule in schedules:
+            if schedule.instructor and schedule.instructor.user.first_name == "Camila":
+                favorite_id = schedule.instructor_id
+                break
+
+        to_create = []
+        for member in members:
+            to_create.extend(
+                self._story_reservations(
+                    member,
+                    schedules,
+                    today,
+                    room.capacity,
+                    occupancy,
+                    spots_taken,
+                    already,
+                    favorite_id,
+                )
+            )
+        if to_create:
+            Reservation.objects.bulk_create(to_create, batch_size=500)
+        return len(to_create)
+
+    def _story_reservations(
+        self,
+        member,
+        schedules,
+        today,
+        capacity,
+        occupancy,
+        spots_taken,
+        already,
+        favorite_id,
+    ):
+        scored = sorted(
+            schedules, key=lambda item: (-self._story_score(item, favorite_id), item.start_time)
+        )
+        used_days = set()
+        per_week = defaultdict(int)
+        member_key = str(member.id)
+        for schedule in schedules:
+            if member_key not in already[str(schedule.id)]:
+                continue
+            local_day = timezone.localtime(schedule.start_time).date()
+            used_days.add(local_day)
+            per_week[_iso_week_start(local_day)] += 1
+        picked = []
+        for schedule in scored:
+            local_dt = timezone.localtime(schedule.start_time)
+            local_day = local_dt.date()
+            week = _iso_week_start(local_day)
+            sid = str(schedule.id)
+            if str(member.id) in already[sid]:
+                continue
+            if occupancy.get(sid, 0) >= capacity:
+                continue
+            if local_day in used_days:
+                continue
+            if per_week[week] >= CLASSES_PER_WEEK:
+                continue
+            free_spot = self._next_spot(spots_taken[sid], capacity)
+            if free_spot is None:
+                continue
+            status = member_constants.RESERVATION_STATUS_RESERVED
+            if local_day < today:
+                status = (
+                    member_constants.RESERVATION_STATUS_MISSED
+                    if (len(picked) % 11 == 10)
+                    else member_constants.RESERVATION_STATUS_ATTENDED
+                )
+            picked.append((schedule, status, free_spot))
+            used_days.add(local_day)
+            per_week[week] += 1
+            occupancy[sid] = occupancy.get(sid, 0) + 1
+            spots_taken[sid].add(free_spot)
+            already[sid].add(str(member.id))
+
+        return [
+            Reservation(
+                member=member,
+                schedule=schedule,
+                status=status,
+                spot=spot,
+                notes=DEMO_RESERVATION_NOTE,
+            )
+            for schedule, status, spot in picked
+        ]
+
+    def _story_score(self, schedule, favorite_id) -> int:
+        hour = timezone.localtime(schedule.start_time).hour
+        title = schedule.title or ""
+        score = 0
+        if hour in (18, 19):
+            score += 5
+        elif hour in (7, 9):
+            score += 2
+        if schedule.instructor_id == favorite_id:
+            score += 4
+        if "POWER" in title:
+            score += 3
+        elif "RIDE" in title:
+            score += 2
+        return score
+
+    def _next_spot(self, taken, capacity):
+        for spot in STORY_SPOTS:
+            if spot not in taken and spot <= capacity:
+                return spot
+        for spot in range(1, capacity + 1):
+            if spot not in taken:
+                return spot
+        return None
 
     def _recent_purchases(self, rng, members, plans, today):
         paid_plans = [plan for plan in plans if "Drop-in" not in plan.name]

--- a/apps/analytics/tests/test_seed_dashboard_demo.py
+++ b/apps/analytics/tests/test_seed_dashboard_demo.py
@@ -1,0 +1,80 @@
+"""Tests for dashboard / member-stats demo seeding."""
+
+from datetime import date, datetime, timezone as dt_timezone
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+
+from apps.analytics.management.commands.seed_dashboard_demo import (
+    DEMO_CLASS_DESCRIPTION,
+    DEMO_RIDER_USERNAME,
+    demo_history_start,
+    demo_horizon_end,
+)
+from apps.analytics.member_stats import get_member_stats
+from apps.members.models import Member, Reservation
+from apps.schedules.models import Schedule
+
+User = get_user_model()
+
+
+def test_demo_horizon_end_covers_october():
+    assert demo_horizon_end(date(2026, 8, 22)) == date(2026, 10, 31)
+    assert demo_horizon_end(date(2026, 10, 31)) == date(2026, 10, 31)
+    assert demo_horizon_end(date(2026, 11, 1)) == date(2027, 10, 31)
+
+
+def test_demo_history_start_is_six_calendar_months():
+    assert demo_history_start(date(2026, 8, 22)) == date(2026, 3, 1)
+
+
+@pytest.mark.django_db
+def test_seed_dashboard_demo_fills_member_charts_through_until():
+    existing = User.objects.create_user(
+        username="axeldiaz",
+        email="axel@example.com",
+        password="pass1234",
+        first_name="Axel",
+        last_name="Díaz",
+    )
+    Member.objects.create(user=existing)
+
+    call_command(
+        "seed_dashboard_demo",
+        history_days=10,
+        until="2026-09-05",
+        as_of="2026-08-22",
+        verbosity=0,
+    )
+
+    last = (
+        Schedule.objects.filter(description=DEMO_CLASS_DESCRIPTION).order_by("-start_time").first()
+    )
+    assert last is not None
+    assert last.start_time.date() == date(2026, 9, 5)
+    assert Reservation.objects.filter(spot__isnull=False).exists()
+
+    now = datetime(2026, 8, 22, 15, 0, tzinfo=dt_timezone.utc)
+    rider = User.objects.get(username=DEMO_RIDER_USERNAME)
+    payload = get_member_stats(rider, now=now)
+    assert payload["classes_attended_total"] > 0
+    assert payload["top_instructors"]
+    assert payload["favorite_classes"]
+    assert sum(payload["preferred_hours"]["values"]) == payload["classes_attended_total"]
+    assert payload["favorite_spots"]
+    assert payload["class_credits"] == 5
+
+    real_payload = get_member_stats(existing, now=now)
+    assert real_payload["classes_attended_total"] > 0
+    assert real_payload["top_instructors"]
+
+    call_command(
+        "seed_dashboard_demo",
+        history_days=10,
+        until="2026-09-05",
+        as_of="2026-08-22",
+        verbosity=0,
+    )
+    second = get_member_stats(existing, now=now)
+    assert second["classes_attended_total"] == real_payload["classes_attended_total"]


### PR DESCRIPTION
## Motivation
Member **Mis estadísticas** charts need attended classes, favorite spots, and upcoming reservations through 31 October.

## Implementation
`seed_dashboard_demo` now:
- Covers six calendar months of history through **31 October**
- Assigns bike spots (and backfills null spots)
- Creates showcase rider `demo.dash.rider` / `demo1234`
- Attaches a 3-classes-per-week story to real members so existing accounts get charts
- Is incremental: re-running fills missing days without duplicating ride stories

## Test Plan
`.venv/bin/python -m pytest apps/analytics/tests/test_seed_dashboard_demo.py -q`

After deploy:
`python manage.py seed_dashboard_demo`

Use `--reset` only if you want to wipe previous `demo.dash.*` rows first.

## Deploy
Run the management command on the target environment after merge. Additive demo data.


Made with [Cursor](https://cursor.com)