### PR TITLE
feat(analytics): seed and report year-to-date member stats

### DIFF
--- a/apps/analytics/management/commands/seed_dashboard_demo.py
+++ b/apps/analytics/management/commands/seed_dashboard_demo.py
@@ -3,7 +3,7 @@
 Idempotent: demo rows are tagged with the `demo.dash.` username prefix.
 Pass --reset to wipe previous demo rows and recreate them.
 
-Schedules cover six calendar months of history through 31 October so the
+Schedules cover year-to-date history (1 January) through 31 October so the
 admin dashboard and member "Mis estadísticas" page have past and upcoming
 classes. Running the command again fills any missing days without duplicating
 rows, backfills bike spots, and attaches a ride history to real members.
@@ -76,13 +76,8 @@ def demo_horizon_end(today: date) -> date:
 
 
 def demo_history_start(today: date) -> date:
-    """First day of the month five months before today (six calendar months)."""
-    year = today.year
-    month = today.month - 5
-    while month <= 0:
-        month += 12
-        year -= 1
-    return date(year, month, 1)
+    """1 January of the current year (year-to-date history)."""
+    return date(today.year, 1, 1)
 
 
 def _iso_week_start(day: date) -> date:
@@ -108,7 +103,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--history-days",
             type=int,
-            help="How many days of history to include (default: six calendar months).",
+            help="How many days of history to include (default: 1 January of this year).",
         )
         parser.add_argument(
             "--as-of",

--- a/apps/analytics/member_stats.py
+++ b/apps/analytics/member_stats.py
@@ -15,7 +15,6 @@ from apps.members.constants import (
 from apps.members.models import Member, Reservation
 from apps.wallets.models import PlanPurchase, Wallet
 
-MONTHS_WINDOW = 6
 STREAK_CHART_WEEKS = 4
 HOUR_RANGE = range(6, 22)
 TOP_COACHES = 5
@@ -31,7 +30,7 @@ CONSUMED_STATUSES = (
 def get_member_stats(user, *, now=None) -> dict:
     now = now or timezone.now()
     today = timezone.localtime(now).date()
-    month_starts = _last_n_month_starts(today, MONTHS_WINDOW)
+    month_starts = _ytd_month_starts(today)
     week_starts = _last_n_week_starts(today, STREAK_CHART_WEEKS)
 
     member = Member.objects.filter(user=user, is_removed=False).first()
@@ -88,8 +87,8 @@ def get_member_stats(user, *, now=None) -> dict:
         if reservation.status == RESERVATION_STATUS_ATTENDED:
             attended_local.append((reservation, local_dt, schedule))
 
-    monthly_classes = [0] * MONTHS_WINDOW
-    monthly_ride_minutes = [0] * MONTHS_WINDOW
+    monthly_classes = [0] * len(month_starts)
+    monthly_ride_minutes = [0] * len(month_starts)
     month_index = {start: i for i, start in enumerate(month_starts)}
     instructor_counts = Counter()
     instructor_last = {}
@@ -212,9 +211,9 @@ def _empty_payload(
         "last_visit": None,
         "total_ride_minutes": 0,
         "monthly_labels": [start.isoformat()[:7] for start in month_starts],
-        "monthly_classes": [0] * MONTHS_WINDOW,
+        "monthly_classes": [0] * len(month_starts),
         "weekly_streak": [False] * len(week_starts),
-        "monthly_ride_minutes": [0] * MONTHS_WINDOW,
+        "monthly_ride_minutes": [0] * len(month_starts),
         "favorite_instructor": None,
         "top_instructors": [],
         "favorite_classes": [],
@@ -250,15 +249,8 @@ def _active_plan(user, now):
     return None
 
 
-def _shift_month(start: date, months: int) -> date:
-    year = start.year + (start.month - 1 + months) // 12
-    month = (start.month - 1 + months) % 12 + 1
-    return date(year, month, 1)
-
-
-def _last_n_month_starts(today: date, n: int) -> list[date]:
-    first = today.replace(day=1)
-    return [_shift_month(first, offset) for offset in range(-(n - 1), 1)]
+def _ytd_month_starts(today: date) -> list[date]:
+    return [date(today.year, month, 1) for month in range(1, today.month + 1)]
 
 
 def _iso_week_start(day: date) -> date:

--- a/apps/analytics/tests/test_member_stats.py
+++ b/apps/analytics/tests/test_member_stats.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 import pytest
 from django.contrib.auth import get_user_model
 from django.urls import reverse
+from django.utils import timezone
 from drf_expiring_token.models import ExpiringToken
 from model_bakery import baker
 
@@ -54,7 +55,7 @@ class TestMemberStatsView:
         assert response.status_code == 200
         assert response.data["classes_completed"] == 0
         assert response.data["favorite_instructor"] is None
-        assert len(response.data["monthly_classes"]) == 6
+        assert len(response.data["monthly_classes"]) == timezone.localdate().month
         assert len(response.data["weekly_streak"]) == 4
 
 
@@ -154,6 +155,7 @@ def test_member_stats_aggregates_attendance_plan_and_favorite():
     assert payload["favorite_instructor"]["instagram_username"] == "tomasride"
     assert payload["classes_completed"] == sum(payload["monthly_classes"])
     assert payload["total_ride_minutes"] > 0
+    assert payload["monthly_labels"][0] == "2026-01"
     assert payload["monthly_labels"][-1] == "2026-08"
     assert payload["class_credits"] == 3
     assert payload["guest_pass_credits"] == 1

--- a/apps/analytics/tests/test_seed_dashboard_demo.py
+++ b/apps/analytics/tests/test_seed_dashboard_demo.py
@@ -25,8 +25,9 @@ def test_demo_horizon_end_covers_october():
     assert demo_horizon_end(date(2026, 11, 1)) == date(2027, 10, 31)
 
 
-def test_demo_history_start_is_six_calendar_months():
-    assert demo_history_start(date(2026, 8, 22)) == date(2026, 3, 1)
+def test_demo_history_start_is_year_to_date():
+    assert demo_history_start(date(2026, 8, 22)) == date(2026, 1, 1)
+    assert demo_history_start(date(2026, 1, 3)) == date(2026, 1, 1)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Motivation
Mis estadísticas needed a full year of history, not only the last six months.

## Implementation
- Demo seed starts on **1 January** of the current year (still through 31 October).
- `GET /api/analytics/me/` monthly series is year-to-date (January → current month).

## Test Plan
`.venv/bin/python -m pytest apps/analytics/tests/test_member_stats.py apps/analytics/tests/test_seed_dashboard_demo.py -q`

Re-run `python manage.py seed_dashboard_demo` after deploy to fill January–today.


Made with [Cursor](https://cursor.com)