### PR TITLE
feat(auth): exchange Clerk session JWTs for Django tokens

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Black
         run: |
           python -m pip install --upgrade pip
-          pip install black
+          pip install black==25.9.0
 
       - name: Show versions
         run: |

--- a/adminstudio_django/settings/base.py
+++ b/adminstudio_django/settings/base.py
@@ -147,6 +147,16 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 DEFAULT_PASSWORD_LENGTH = 13
 
+CLERK_SECRET_KEY = os.environ.get("CLERK_SECRET_KEY", "")
+CLERK_JWKS_URL = os.environ.get("CLERK_JWKS_URL", "")
+_clerk_parties = os.environ.get(
+    "CLERK_AUTHORIZED_PARTIES",
+    "https://studio.axeldiaz.com,http://localhost:5173,http://127.0.0.1:5173",
+)
+CLERK_AUTHORIZED_PARTIES = [
+    origin.strip() for origin in _clerk_parties.split(",") if origin.strip()
+]
+
 # Email configuration
 # For Mailtrap (recommended for development/testing):
 #   EMAIL_HOST=sandbox.smtp.mailtrap.io

--- a/apps/users/clerk.py
+++ b/apps/users/clerk.py
@@ -1,0 +1,104 @@
+"""Verify Clerk session JWTs and load the Clerk user profile."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import jwt
+import requests
+from django.conf import settings
+from jwt import PyJWKClient
+
+_jwks_client: PyJWKClient | None = None
+
+
+class ClerkAuthError(Exception):
+    """The Clerk session token is missing, invalid, or the user cannot be resolved."""
+
+
+@dataclass(frozen=True)
+class ClerkProfile:
+    clerk_user_id: str
+    email: str
+    first_name: str
+    last_name: str
+    phone_number: str
+
+
+def _jwks_client_for_settings() -> PyJWKClient:
+    global _jwks_client
+    jwks_url = getattr(settings, "CLERK_JWKS_URL", "") or ""
+    if not jwks_url:
+        raise ClerkAuthError("Clerk is not configured")
+    if _jwks_client is None or _jwks_client.uri != jwks_url:
+        _jwks_client = PyJWKClient(jwks_url, cache_keys=True)
+    return _jwks_client
+
+
+def verify_clerk_session_token(token: str) -> dict:
+    """Decode and verify a Clerk session JWT. Raises ClerkAuthError on failure."""
+    if not token or not token.strip():
+        raise ClerkAuthError("Missing Clerk session token")
+
+    try:
+        client = _jwks_client_for_settings()
+        signing_key = client.get_signing_key_from_jwt(token)
+        claims = jwt.decode(
+            token,
+            signing_key.key,
+            algorithms=["RS256"],
+            options={"verify_aud": False},
+            leeway=10,
+        )
+    except ClerkAuthError:
+        raise
+    except Exception as exc:
+        raise ClerkAuthError("Invalid Clerk session token") from exc
+
+    parties = getattr(settings, "CLERK_AUTHORIZED_PARTIES", None) or []
+    azp = claims.get("azp")
+    if parties and azp and azp not in parties:
+        raise ClerkAuthError("Invalid Clerk authorized party")
+
+    if not claims.get("sub"):
+        raise ClerkAuthError("Clerk token is missing subject")
+    return claims
+
+
+def fetch_clerk_user(clerk_user_id: str) -> ClerkProfile:
+    secret = getattr(settings, "CLERK_SECRET_KEY", "") or ""
+    if not secret:
+        raise ClerkAuthError("Clerk is not configured")
+
+    response = requests.get(
+        f"https://api.clerk.com/v1/users/{clerk_user_id}",
+        headers={"Authorization": f"Bearer {secret}"},
+        timeout=10,
+    )
+    if response.status_code != 200:
+        raise ClerkAuthError("Could not load Clerk user")
+
+    data = response.json()
+    primary_id = data.get("primary_email_address_id")
+    emails = data.get("email_addresses") or []
+    email = ""
+    for item in emails:
+        if item.get("id") == primary_id or not email:
+            email = (item.get("email_address") or "").strip()
+            if item.get("id") == primary_id:
+                break
+    if not email:
+        raise ClerkAuthError("Clerk user has no email")
+
+    phones = data.get("phone_numbers") or []
+    phone = ""
+    if phones:
+        phone = (phones[0].get("phone_number") or "").strip()
+
+    return ClerkProfile(
+        clerk_user_id=clerk_user_id,
+        email=email,
+        first_name=(data.get("first_name") or "").strip(),
+        last_name=(data.get("last_name") or "").strip(),
+        phone_number=phone,
+    )

--- a/apps/users/services.py
+++ b/apps/users/services.py
@@ -12,8 +12,11 @@ from django.core.exceptions import ValidationError
 from django.db.models import Q
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
+from drf_expiring_token.models import ExpiringToken
 
+from apps.members.models import Member
 from apps.users import constants
+from apps.users.clerk import fetch_clerk_user, verify_clerk_session_token
 from apps.users.models import EmailChangeRequest, PasswordResetCode
 from apps.users.schemas import (
     UserSchema,
@@ -85,6 +88,45 @@ def get_or_create_user(data: dict) -> User:
     except User.DoesNotExist:
         user = create_user(data)
     return user
+
+
+def exchange_clerk_session(session_token: str) -> tuple[User, ExpiringToken]:
+    """Verify a Clerk session JWT and return the local user plus a DRF token."""
+    claims = verify_clerk_session_token(session_token)
+    profile = fetch_clerk_user(claims["sub"])
+
+    user = User.objects.filter(email__iexact=profile.email).first()
+    if user is None:
+        user = create_user(
+            {
+                "email": profile.email,
+                "first_name": profile.first_name,
+                "last_name": profile.last_name,
+                "phone_number": profile.phone_number,
+                "is_active": True,
+            }
+        )
+    else:
+        dirty: list[str] = []
+        if not user.is_active:
+            user.is_active = True
+            dirty.append("is_active")
+        if profile.first_name and not user.first_name:
+            user.first_name = profile.first_name
+            dirty.append("first_name")
+        if profile.last_name and not user.last_name:
+            user.last_name = profile.last_name
+            dirty.append("last_name")
+        if profile.phone_number and not user.phone_number:
+            user.phone_number = profile.phone_number
+            dirty.append("phone_number")
+        if dirty:
+            user.save(update_fields=dirty)
+
+    Member.objects.get_or_create(user=user)
+    ExpiringToken.objects.filter(user=user).delete()
+    token = ExpiringToken.objects.create(user=user)
+    return user, token
 
 
 def get_user_profile(user: User) -> UserProfileResponseSchema:

--- a/apps/users/tests/test_clerk.py
+++ b/apps/users/tests/test_clerk.py
@@ -1,0 +1,102 @@
+from unittest.mock import patch
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from drf_expiring_token.models import ExpiringToken
+
+from apps.members.models import Member
+from apps.users.clerk import ClerkAuthError, ClerkProfile
+from apps.users.services import exchange_clerk_session
+
+User = get_user_model()
+
+
+def _profile(**overrides):
+    data = dict(
+        clerk_user_id="user_abc",
+        email="rider@example.com",
+        first_name="Ana",
+        last_name="Rider",
+        phone_number="+56911111111",
+    )
+    data.update(overrides)
+    return ClerkProfile(**data)
+
+
+@pytest.mark.django_db
+class TestExchangeClerkSession:
+    def test_creates_active_member_and_token(self):
+        with (
+            patch(
+                "apps.users.services.verify_clerk_session_token", return_value={"sub": "user_abc"}
+            ),
+            patch("apps.users.services.fetch_clerk_user", return_value=_profile()),
+        ):
+            user, token = exchange_clerk_session("jwt-token")
+
+        assert user.email == "rider@example.com"
+        assert user.is_active is True
+        assert user.first_name == "Ana"
+        assert Member.objects.filter(user=user).exists()
+        assert token.user == user
+        assert ExpiringToken.objects.filter(user=user).count() == 1
+
+    def test_links_existing_email_and_activates(self):
+        existing = User.objects.create_user(
+            username="old@example.com",
+            email="rider@example.com",
+            password="pass1234",
+            is_active=False,
+        )
+        with (
+            patch(
+                "apps.users.services.verify_clerk_session_token", return_value={"sub": "user_abc"}
+            ),
+            patch("apps.users.services.fetch_clerk_user", return_value=_profile()),
+        ):
+            user, token = exchange_clerk_session("jwt-token")
+
+        assert user.id == existing.id
+        user.refresh_from_db()
+        assert user.is_active is True
+        assert token.user == user
+
+    def test_rejects_invalid_token(self):
+        with patch(
+            "apps.users.services.verify_clerk_session_token",
+            side_effect=ClerkAuthError("Invalid Clerk session token"),
+        ):
+            with pytest.raises(ClerkAuthError):
+                exchange_clerk_session("bad")
+
+
+@pytest.mark.django_db
+class TestClerkSessionView:
+    def test_requires_bearer_token(self, api_client):
+        url = reverse("users:clerk")
+        response = api_client.post(url, {}, format="json")
+        assert response.status_code == 401
+
+    def test_returns_django_token(self, api_client):
+        url = reverse("users:clerk")
+        with (patch("apps.users.views.exchange_clerk_session") as exchange,):
+            user = User.objects.create_user(
+                username="rider@example.com",
+                email="rider@example.com",
+                password="pass1234",
+                first_name="Ana",
+            )
+            token = ExpiringToken.objects.create(user=user)
+            exchange.return_value = (user, token)
+            response = api_client.post(
+                url,
+                {},
+                format="json",
+                HTTP_AUTHORIZATION="Bearer clerk-jwt",
+            )
+
+        assert response.status_code == 200
+        assert response.data["token"] == token.key
+        assert response.data["user"]["email"] == "rider@example.com"
+        exchange.assert_called_once_with("clerk-jwt")

--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 
 from apps.users.views import (
     LoginView,
+    ClerkSessionView,
     CurrentUserView,
     AdminUserListView,
     AdminUserDetailView,
@@ -17,6 +18,7 @@ app_name = "users"
 
 urlpatterns = [
     path("login/", LoginView.as_view(), name="login"),
+    path("clerk/", ClerkSessionView.as_view(), name="clerk"),
     path("me/", CurrentUserView.as_view(), name="me"),
     path("users/", AdminUserListView.as_view(), name="users"),
     path(

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -17,10 +17,12 @@ from apps.users.serializers import (
 from pydantic import ValidationError as PydanticValidationError
 
 from apps.users.schemas import AdminUserUpdateSchema, CurrentUserSchema
+from apps.users.clerk import ClerkAuthError
 from apps.users.services import (
     change_user_password,
     request_password_recovery,
     confirm_password_reset,
+    exchange_clerk_session,
     get_admin_user,
     list_admin_users,
     request_admin_password_recovery,
@@ -85,6 +87,33 @@ class LoginView(APIView):
                 "token": token.key,
                 "user": user_data,
             },
+            status=status.HTTP_200_OK,
+        )
+
+
+class ClerkSessionView(APIView):
+    """Exchange a Clerk session JWT for a Django expiring token."""
+
+    authentication_classes = []
+    permission_classes = [AllowAny]
+
+    def post(self, request, *args, **kwargs):
+        header = request.META.get("HTTP_AUTHORIZATION") or ""
+        scheme, _, credential = header.partition(" ")
+        if scheme.lower() != "bearer" or not credential.strip():
+            return Response(
+                {"detail": "Missing Clerk session token."},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+
+        try:
+            user, token = exchange_clerk_session(credential.strip())
+        except ClerkAuthError as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_401_UNAUTHORIZED)
+
+        user_data = CurrentUserSchema.model_validate(user).model_dump(mode="json")
+        return Response(
+            {"token": token.key, "user": user_data},
             status=status.HTTP_200_OK,
         )
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,6 +11,8 @@ pytest-mock==3.15.1
 model_bakery==1.20.5
 email-validator==2.3.0
 requests==2.32.5
+PyJWT==2.10.1
+cryptography>=45.0.6
 Pillow==12.0.0
 markdown==3.10
 Pygments==2.19.2


### PR DESCRIPTION
## Summary
- Add `POST /api/auth/clerk/` to verify a Clerk session JWT, link or create the local user (and member), and return an expiring DRF token.
- Configure `CLERK_SECRET_KEY`, `CLERK_JWKS_URL`, and `CLERK_AUTHORIZED_PARTIES`.

## Test plan
- [ ] `pytest apps/users/tests/test_clerk.py`
- [ ] Sign in on the SPA with Clerk; Django `/api/auth/me/` should succeed with `Token`.
- [ ] Existing email addresses keep staff/coach flags.


Made with [Cursor](https://cursor.com)