### PR TITLE
fix(users): keep Axel Díaz and Instagram on preserved axelio seed

### DIFF
--- a/apps/users/management/commands/seed_demo_catalog.py
+++ b/apps/users/management/commands/seed_demo_catalog.py
@@ -206,6 +206,9 @@ class Command(BaseCommand):
                 instructor.save()
             Member.objects.get_or_create(user=user)
             if is_preserved_username(user.username):
+                # Stable real identity for axelio — seeds must not blank these out.
+                user.first_name = "Axel"
+                user.last_name = "Díaz"
                 if not user.phone_number:
                     user.phone_number = "+56900001111"
                 if not user.address:
@@ -221,6 +224,10 @@ class Command(BaseCommand):
                 if user.cycling_shoe_size is None:
                     user.cycling_shoe_size = Decimal("42.0")
                 user.save()
+                instructor.instagram_username = "axeliodiaz"
+                if not instructor.tagline:
+                    instructor.tagline = "Indoor cycling"
+                instructor.save()
 
         return instructors
 

--- a/apps/users/tests/test_versioned_fixtures.py
+++ b/apps/users/tests/test_versioned_fixtures.py
@@ -29,6 +29,8 @@ def test_seed_demo_catalog_creates_kristina_and_preserves_axelio():
     axel.refresh_from_db()
     assert axel.first_name == "Axel"
     assert axel.last_name == "Díaz"
+    axel_instructor = Instructor.objects.get(user=axel)
+    assert axel_instructor.instagram_username == "axeliodiaz"
     kristina = User.objects.get(username="kristina.girod")
     assert kristina.first_name == "Kristina"
     instructor = Instructor.objects.get(user=kristina)


### PR DESCRIPTION
## Summary
- \`seed_demo_catalog\` always sets preserved \`axelio\` to first_name Axel, last_name Díaz, and Instagram \`axeliodiaz\`.
- Test asserts Instagram survives the seed.

## Test plan
- [ ] \`pytest apps/users/tests/test_versioned_fixtures.py\`
- [ ] Prod row already updated: Axel / Díaz / axeliodiaz


Made with [Cursor](https://cursor.com)