### PR TITLE
fix(instructors): pass through absolute profile image URLs

### DIFF
--- a/apps/coach/services.py
+++ b/apps/coach/services.py
@@ -26,12 +26,17 @@ def get_instructor_for_user(user: User) -> Instructor:
 
 
 def _profile_image_url(value) -> str | None:
+    """Return a usable image URL. Absolute http(s) names are returned as-is."""
     try:
-        if value and getattr(value, "name", ""):
-            return value.url
+        name = getattr(value, "name", None) or ""
+        if not name:
+            return None
+        name_str = str(name)
+        if name_str.startswith(("http://", "https://")):
+            return name_str
+        return value.url
     except Exception:
         return None
-    return None
 
 
 def _as_list(value) -> list[str]:

--- a/apps/instructors/schemas.py
+++ b/apps/instructors/schemas.py
@@ -37,12 +37,7 @@ class InstructorSchema(BaseModel):
 
     @field_serializer("profile_image", when_used="always")
     def serialize_profile_image(self, value):
-        try:
-            if value and getattr(value, "name", ""):
-                return value.url
-        except Exception:
-            return None
-        return None
+        return _profile_image_url(value)
 
 
 class InstructorPublicSchema(BaseModel):
@@ -75,21 +70,21 @@ class InstructorPublicSchema(BaseModel):
 
     @field_serializer("profile_image", when_used="always")
     def serialize_profile_image(self, value):
-        try:
-            if value and getattr(value, "name", ""):
-                return value.url
-        except Exception:
-            return None
-        return None
+        return _profile_image_url(value)
 
 
 def _profile_image_url(value) -> str | None:
+    """Return a usable image URL. Absolute http(s) names are returned as-is."""
     try:
-        if value and getattr(value, "name", ""):
-            return value.url
+        name = getattr(value, "name", None) or ""
+        if not name:
+            return None
+        name_str = str(name)
+        if name_str.startswith(("http://", "https://")):
+            return name_str
+        return value.url
     except Exception:
         return None
-    return None
 
 
 class AdminInstructorSchema(BaseModel):


### PR DESCRIPTION
## Summary
- ImageField storage was prefixing \`/media/\` onto absolute \`https://studio.axeldiaz.com/coaches/…\` paths.
- Serializers now return absolute http(s) names unchanged so Vercel-hosted coach photos work.

## Test plan
- [ ] GET \`/api/instructors/instructors/\` returns \`profile_image\` starting with \`https://studio.axeldiaz.com/coaches/\`
- [ ] Instructor cards show photos after front deploy


Made with [Cursor](https://cursor.com)