### PR TITLE
fix(demo): set Kristina Instagram to thekristinagirod

### DIFF
--- a/apps/users/demo_catalog.py
+++ b/apps/users/demo_catalog.py
@@ -108,7 +108,7 @@ INSTRUCTORS: tuple[Persona, ...] = (
             "Si el puesto 1 está libre, no lo está: lo está guardando el destino."
         ),
         website_path="coaches/kristina-girod",
-        instagram_username="kristinagirod",
+        instagram_username="thekristinagirod",
         tiktok_username="kristina.girod.ride",
         is_verified=True,
         instructor_since=date(2016, 5, 1),

--- a/apps/users/tests/test_versioned_fixtures.py
+++ b/apps/users/tests/test_versioned_fixtures.py
@@ -35,7 +35,7 @@ def test_seed_demo_catalog_creates_kristina_and_preserves_axelio():
     assert kristina.first_name == "Kristina"
     instructor = Instructor.objects.get(user=kristina)
     assert instructor.tagline
-    assert instructor.instagram_username == "kristinagirod"
+    assert instructor.instagram_username == "thekristinagirod"
     assert instructor.website_url == f"https://{settings.EMAIL_DOMAIN}/coaches/kristina-girod"
     assert kristina.email == f"kristina_girod@{settings.EMAIL_DOMAIN}"
     assert kristina.address


### PR DESCRIPTION
## Summary
- Seed persona Instagram for Kristina is now \`thekristinagirod\`.
- Align versioned-fixture test with the new handle.

## Test plan
- [ ] \`pytest apps/users/tests/test_versioned_fixtures.py\`
- [ ] After seed/redeploy, Kristina instructor Instagram stays \`thekristinagirod\`


Made with [Cursor](https://cursor.com)