### PR TITLE
feat(schedules): filter the public class list on the server

### DIFF
--- a/apps/instructors/instructors.py
+++ b/apps/instructors/instructors.py
@@ -68,4 +68,4 @@ def get_instructor_from_id(pk) -> Instructor:
 
 def instructors_queryset():
     """Return a queryset of all instructors."""
-    return Instructor.objects.all()
+    return Instructor.objects.select_related("user").all()

--- a/apps/schedules/schedules.py
+++ b/apps/schedules/schedules.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Iterable
 from uuid import UUID
+
+from django.db.models import Q
 
 from apps.instructors.services import get_instructor_by_id
 from apps.schedules import constants
@@ -17,25 +20,65 @@ def get_schedule_by_id(schedule_id: UUID | str) -> Schedule:
 def get_schedules_list(
     *,
     start_time: datetime | None = None,
+    end_time: datetime | None = None,
     instructor_id: UUID | str | None = None,
+    instructor_ids: Iterable[UUID | str] | None = None,
     instructor_username: str | None = None,
     room_name: str | None = None,
+    room_id: UUID | str | None = None,
+    room_ids: Iterable[UUID | str] | None = None,
+    title: str | None = None,
+    titles: Iterable[str] | None = None,
 ):
     """Return queryset of schedules ordered by start_time.
 
-    Optionally filter by start_time (>= provided value), by instructor id or instructor username,
-    and/or by room name when provided.
-    This helper replaces direct usages of Schedule.objects.all().order_by("start_time").
+    Filters are combined with AND. ``titles`` matches if the schedule title
+    contains any of the given strings (case-insensitive).
     """
-    qs = Schedule.objects.select_related("room")
+    qs = Schedule.objects.select_related(
+        "instructor__user",
+        "room__studio__address",
+    )
     if start_time is not None:
         qs = qs.filter(start_time__gte=start_time)
+    if end_time is not None:
+        qs = qs.filter(start_time__lte=end_time)
+
+    instructor_keys = [str(value) for value in (instructor_ids or []) if value]
     if instructor_id:
-        qs = qs.filter(instructor_id=instructor_id)
+        instructor_keys.append(str(instructor_id))
+    instructor_keys = list(dict.fromkeys(instructor_keys))
+    if len(instructor_keys) == 1:
+        qs = qs.filter(instructor_id=instructor_keys[0])
+    elif instructor_keys:
+        qs = qs.filter(instructor_id__in=instructor_keys)
+
     if instructor_username:
         qs = qs.filter(instructor__user__username__icontains=instructor_username)
     if room_name:
         qs = qs.filter(room__name__icontains=room_name)
+
+    room_keys = [str(value) for value in (room_ids or []) if value]
+    if room_id:
+        room_keys.append(str(room_id))
+    room_keys = list(dict.fromkeys(room_keys))
+    if len(room_keys) == 1:
+        qs = qs.filter(room_id=room_keys[0])
+    elif room_keys:
+        qs = qs.filter(room_id__in=room_keys)
+
+    title_terms = [str(value).strip() for value in (titles or []) if str(value).strip()]
+    if title and title.strip():
+        title_terms.append(title.strip())
+    title_terms = list(dict.fromkeys(title_terms))
+    if len(title_terms) == 1:
+        qs = qs.filter(title__icontains=title_terms[0])
+    elif title_terms:
+        title_query = Q()
+        for term in title_terms:
+            title_query |= Q(title__icontains=term)
+        qs = qs.filter(title_query)
+
     return qs.order_by("start_time")
 
 

--- a/apps/schedules/schemas.py
+++ b/apps/schedules/schemas.py
@@ -11,9 +11,14 @@ class ScheduleSchema(BaseModel):
     created: datetime
     modified: datetime
     instructor_id: uuid.UUID
+    instructor_name: str = ""
     start_time: datetime
     duration_minutes: int
     room_id: uuid.UUID
+    room_name: str = ""
+    studio_id: uuid.UUID | None = None
+    studio_name: str | None = None
+    studio_address: str | None = None
     status: str
     capacity: int | None = None
     booked_count: int = 0

--- a/apps/schedules/services.py
+++ b/apps/schedules/services.py
@@ -53,29 +53,78 @@ def create_schedule(
     return ScheduleSchema.model_validate(schedule)
 
 
+def _annotate_occupancy(queryset):
+    """Attach booked/waitlist counts in two aggregated queries instead of per row."""
+    return queryset.annotate(
+        booked_count=Count(
+            "reservations",
+            filter=Q(
+                reservations__is_removed=False,
+                reservations__status=member_constants.RESERVATION_STATUS_RESERVED,
+            ),
+            distinct=True,
+        ),
+        waitlist_count=Count(
+            "waitlist_entries",
+            filter=Q(
+                waitlist_entries__is_removed=False,
+                waitlist_entries__status__in=member_constants.WAITLIST_ACTIVE_STATUSES,
+            ),
+            distinct=True,
+        ),
+    )
+
+
+def _studio_address(schedule: Schedule) -> str | None:
+    room = getattr(schedule, "room", None)
+    studio = getattr(room, "studio", None) if room else None
+    address = getattr(studio, "address", None) if studio else None
+    value = getattr(address, "address", None) if address else None
+    return value or None
+
+
+def _schedule_display_fields(schedule: Schedule) -> dict:
+    room = getattr(schedule, "room", None)
+    studio = getattr(room, "studio", None) if room else None
+    return {
+        "instructor_name": _instructor_display_name(schedule),
+        "room_name": room.name if room else "",
+        "studio_id": studio.id if studio else None,
+        "studio_name": studio.name if studio else None,
+        "studio_address": _studio_address(schedule),
+    }
+
+
 def _schedule_occupancy(schedule: Schedule) -> dict:
     room = getattr(schedule, "room", None)
     capacity = room.capacity if room else None
-    booked = Reservation.objects.filter(
-        schedule_id=schedule.id,
-        status=member_constants.RESERVATION_STATUS_RESERVED,
-        is_removed=False,
-    ).count()
-    waitlist_count = WaitlistEntry.objects.filter(
-        schedule_id=schedule.id,
-        is_removed=False,
-        status__in=member_constants.WAITLIST_ACTIVE_STATUSES,
-    ).count()
+    booked = getattr(schedule, "booked_count", None)
+    if booked is None:
+        booked = Reservation.objects.filter(
+            schedule_id=schedule.id,
+            status=member_constants.RESERVATION_STATUS_RESERVED,
+            is_removed=False,
+        ).count()
+    waitlist_count = getattr(schedule, "waitlist_count", None)
+    if waitlist_count is None:
+        waitlist_count = WaitlistEntry.objects.filter(
+            schedule_id=schedule.id,
+            is_removed=False,
+            status__in=member_constants.WAITLIST_ACTIVE_STATUSES,
+        ).count()
     return {
         "capacity": capacity,
         "booked_count": booked,
         "waitlist_count": waitlist_count,
         "is_full": bool(capacity is not None and booked >= capacity),
+        **_schedule_display_fields(schedule),
     }
 
 
 def to_schedule_schema_list(items: Iterable) -> List[ScheduleSchema]:
     """Convert iterable of Schedule model instances to a list of ScheduleSchema."""
+    if hasattr(items, "annotate"):
+        items = _annotate_occupancy(items)
     schemas = []
     for obj in items:
         schema = ScheduleSchema.model_validate(obj)
@@ -86,18 +135,27 @@ def to_schedule_schema_list(items: Iterable) -> List[ScheduleSchema]:
 def get_schedule_schema_list(
     *,
     start_time: datetime | None = None,
+    end_time: datetime | None = None,
     instructor_id: UUID | str | None = None,
+    instructor_ids: Iterable[UUID | str] | None = None,
     room_name: str | None = None,
+    room_id: UUID | str | None = None,
+    room_ids: Iterable[UUID | str] | None = None,
+    title: str | None = None,
+    titles: Iterable[str] | None = None,
 ) -> List[ScheduleSchema]:
-    """Fetch schedules ordered by start_time and return as list of ScheduleSchema.
-
-    If start_time is provided, filter schedules by start_time (>= provided). Optionally filter by instructor id and/or room name.
-    """
+    """Fetch schedules ordered by start_time and return as list of ScheduleSchema."""
     return to_schedule_schema_list(
         get_schedules_list(
             start_time=start_time,
+            end_time=end_time,
             instructor_id=instructor_id,
+            instructor_ids=instructor_ids,
             room_name=room_name,
+            room_id=room_id,
+            room_ids=room_ids,
+            title=title,
+            titles=titles,
         )
     )
 

--- a/apps/schedules/tests/test_schedules.py
+++ b/apps/schedules/tests/test_schedules.py
@@ -42,15 +42,44 @@ class TestGetSchedulesList:
         assert ids == {schedules_sample[0].id, schedules_sample[2].id}
 
     @pytest.mark.django_db
-    def test_combined_filters(self, schedules_sample):
-        threshold = schedules_sample[0].start_time + timedelta(minutes=30)
-        qs = get_schedules_list(
-            start_time=threshold,
-            instructor_id=str(schedules_sample[0].instructor_id),
-            room_name="small",
+    def test_filters_by_end_time_lte(self, schedules_sample):
+        threshold = schedules_sample[1].start_time
+        qs = get_schedules_list(end_time=threshold)
+        ids = set(qs.values_list("id", flat=True))
+        assert ids == {schedules_sample[0].id, schedules_sample[1].id}
+
+    @pytest.mark.django_db
+    def test_filters_by_room_id(self, schedules_sample, room_small):
+        qs = get_schedules_list(room_id=str(room_small.id))
+        ids = set(qs.values_list("id", flat=True))
+        assert ids == {schedules_sample[1].id}
+
+    @pytest.mark.django_db
+    def test_filters_by_multiple_instructor_ids(
+        self, schedules_sample, instructor_alice, instructor_bob
+    ):
+        qs = get_schedules_list(instructor_ids=[str(instructor_alice.id), str(instructor_bob.id)])
+        assert qs.count() == 3
+
+    @pytest.mark.django_db
+    def test_filters_by_title_icontains(self, instructor_alice, room_main):
+        baker.make(
+            "schedules.Schedule",
+            instructor=instructor_alice,
+            room=room_main,
+            title="RIDE 45",
+            start_time=datetime(2025, 2, 1, 10, 0, tzinfo=timezone.utc),
         )
-        ids = list(qs.values_list("id", flat=True))
-        assert ids == [schedules_sample[1].id]
+        baker.make(
+            "schedules.Schedule",
+            instructor=instructor_alice,
+            room=room_main,
+            title="Pilates",
+            start_time=datetime(2025, 2, 1, 11, 0, tzinfo=timezone.utc),
+        )
+        qs = get_schedules_list(titles=["RIDE"])
+        assert qs.count() == 1
+        assert qs.get().title == "RIDE 45"
 
 
 class TestCreateSchedule:

--- a/apps/schedules/tests/test_services.py
+++ b/apps/schedules/tests/test_services.py
@@ -42,15 +42,29 @@ class TestServicesGetScheduleSchemaList:
         assert ids == {schedules_sample[0].id, schedules_sample[2].id}
 
     @pytest.mark.django_db
-    def test_combined_filters(self, schedules_sample):
-        threshold = schedules_sample[0].start_time + timedelta(minutes=30)
-        schemas = get_schedule_schema_list(
-            start_time=threshold,
-            instructor_id=str(schedules_sample[0].instructor_id),
-            room_name="small",
+    def test_filters_by_end_time(self, schedules_sample):
+        threshold = schedules_sample[1].start_time
+        schemas = get_schedule_schema_list(end_time=threshold)
+        ids = {s.id for s in schemas}
+        assert ids == {schedules_sample[0].id, schedules_sample[1].id}
+
+    @pytest.mark.django_db
+    def test_occupancy_uses_annotated_counts(self, schedules_sample):
+        from apps.members import constants as member_constants
+
+        schedule = schedules_sample[0]
+        member = baker.make("members.Member")
+        baker.make(
+            "members.Reservation",
+            member=member,
+            schedule=schedule,
+            status=member_constants.RESERVATION_STATUS_RESERVED,
+            is_removed=False,
+            spot=1,
         )
-        ids = [s.id for s in schemas]
-        assert ids == [schedules_sample[1].id]
+        schemas = {row.id: row for row in get_schedule_schema_list()}
+        assert schemas[schedule.id].booked_count == 1
+        assert schemas[schedules_sample[1].id].booked_count == 0
 
 
 class TestServicesCreateSchedule:

--- a/apps/schedules/tests/test_views.py
+++ b/apps/schedules/tests/test_views.py
@@ -54,21 +54,68 @@ class TestScheduleViewSetList:
         assert ids == {str(schedules_sample[0].id), str(schedules_sample[2].id)}
 
     @pytest.mark.django_db
-    def test_list_combined_filters(self, api_client, schedules_sample):
-        threshold = (
-            (schedules_sample[0].start_time + timedelta(minutes=30))
-            .isoformat()
-            .replace("+00:00", "Z")
+    def test_list_filter_by_start_and_end_date(self, api_client, schedules_sample):
+        resp = api_client.get(
+            reverse("schedule-list"),
+            {"start_date": "2025-01-01", "end_date": "2025-01-01"},
         )
-        params = {
-            "start_time": threshold,
-            "instructor_id": str(schedules_sample[0].instructor_id),
-            "room_name": "small",
-        }
+        assert resp.status_code == status.HTTP_200_OK
+        assert len(resp.json()) == 3
+
+        empty = api_client.get(
+            reverse("schedule-list"),
+            {"start_date": "2025-01-02", "end_date": "2025-01-02"},
+        )
+        assert empty.status_code == status.HTTP_200_OK
+        assert empty.json() == []
+
+    @pytest.mark.django_db
+    def test_list_filter_by_end_time(self, api_client, schedules_sample):
+        threshold = schedules_sample[0].start_time.isoformat().replace("+00:00", "Z")
+        resp = api_client.get(reverse("schedule-list"), {"end_time": threshold})
+        assert resp.status_code == status.HTTP_200_OK
+        ids = {item["id"] for item in resp.json()}
+        assert ids == {str(schedules_sample[0].id)}
+
+    @pytest.mark.django_db
+    def test_list_filter_by_room_id(self, api_client, schedules_sample):
+        room_id = str(schedules_sample[1].room_id)
+        resp = api_client.get(reverse("schedule-list"), {"room_id": room_id})
+        assert resp.status_code == status.HTTP_200_OK
+        ids = {item["id"] for item in resp.json()}
+        assert ids == {str(schedules_sample[1].id)}
+
+    @pytest.mark.django_db
+    def test_list_filter_by_multiple_instructor_ids(self, api_client, schedules_sample):
+        params = [
+            ("instructor_id", str(schedules_sample[0].instructor_id)),
+            ("instructor_id", str(schedules_sample[2].instructor_id)),
+        ]
         resp = api_client.get(reverse("schedule-list"), params)
         assert resp.status_code == status.HTTP_200_OK
-        data = resp.json()
-        assert [item["id"] for item in data] == [str(schedules_sample[1].id)]
+        ids = {item["id"] for item in resp.json()}
+        assert ids == {
+            str(schedules_sample[0].id),
+            str(schedules_sample[1].id),
+            str(schedules_sample[2].id),
+        }
+
+    @pytest.mark.django_db
+    def test_list_includes_related_display_fields(self, api_client, schedules_sample):
+        resp = api_client.get(reverse("schedule-list"))
+        assert resp.status_code == status.HTTP_200_OK
+        row = resp.json()[0]
+        assert "instructor_name" in row
+        assert "room_name" in row
+        assert "studio_name" in row
+        assert "booked_count" in row
+        assert "is_full" in row
+
+    @pytest.mark.django_db
+    def test_list_invalid_start_date_returns_400(self, api_client):
+        resp = api_client.get(reverse("schedule-list"), {"start_date": "not-a-date"})
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert "Invalid start_date format" in resp.json().get("detail", "")
 
 
 class TestScheduleViewSetRetrieve:

--- a/apps/schedules/views.py
+++ b/apps/schedules/views.py
@@ -17,7 +17,10 @@ from apps.schedules.services import (
     update_admin_schedule,
 )
 
-from django.utils.dateparse import parse_datetime
+from datetime import datetime, time, timedelta
+
+from django.utils.dateparse import parse_date, parse_datetime
+from django.utils.timezone import get_default_timezone, make_aware
 from uuid import UUID
 
 from pydantic import ValidationError as PydanticValidationError
@@ -47,6 +50,49 @@ def _parse_datetime_param(value: str | None, field_name: str):
     return parsed
 
 
+def _parse_date_param(value: str | None, field_name: str):
+    if not value:
+        return None
+    parsed = parse_date(value)
+    if parsed is None:
+        return Response(
+            {"detail": f"Invalid {field_name} format. Use YYYY-MM-DD."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+    return parsed
+
+
+def _aware_day_start(day) -> datetime:
+    tz = get_default_timezone()
+    return make_aware(datetime.combine(day, time.min), tz)
+
+
+def _bounds_from_dates(start_date, end_date) -> tuple[datetime | None, datetime | None]:
+    start_bound = _aware_day_start(start_date) if start_date else None
+    if end_date:
+        end_bound = _aware_day_start(end_date) + timedelta(days=1) - timedelta(microseconds=1)
+    else:
+        end_bound = None
+    return start_bound, end_bound
+
+
+def _parse_uuid_list(request, field_name: str):
+    values: list[UUID] = []
+    for raw in request.query_params.getlist(field_name):
+        for part in str(raw).split(","):
+            part = part.strip()
+            if not part:
+                continue
+            try:
+                values.append(UUID(part))
+            except (ValueError, TypeError):
+                return Response(
+                    {"detail": f"Invalid {field_name} format."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+    return values
+
+
 class ScheduleViewSet(viewsets.ViewSet):
     """Minimal viewset for schedules: list, retrieve, create."""
 
@@ -59,16 +105,51 @@ class ScheduleViewSet(viewsets.ViewSet):
         return parsed
 
     def list(self, request):
-        start_time_str = request.query_params.get("start_time")
-        start_time = self._get_start_time_params(start_time_str)
+        start_time = self._get_start_time_params(request.query_params.get("start_time"))
         if isinstance(start_time, Response):
             return start_time
-        instructor_id = request.query_params.get("instructor_id")
-        room_name = request.query_params.get("room_name")
+        end_time = _parse_datetime_param(request.query_params.get("end_time"), "end_time")
+        if isinstance(end_time, Response):
+            return end_time
+        start_date = _parse_date_param(request.query_params.get("start_date"), "start_date")
+        if isinstance(start_date, Response):
+            return start_date
+        end_date = _parse_date_param(request.query_params.get("end_date"), "end_date")
+        if isinstance(end_date, Response):
+            return end_date
+
+        date_start, date_end = _bounds_from_dates(start_date, end_date)
+        if start_time is None:
+            start_time = date_start
+        elif date_start is not None:
+            start_time = max(start_time, date_start)
+        if end_time is None:
+            end_time = date_end
+        elif date_end is not None:
+            end_time = min(end_time, date_end)
+
+        instructor_ids = _parse_uuid_list(request, "instructor_id")
+        if isinstance(instructor_ids, Response):
+            return instructor_ids
+        room_ids = _parse_uuid_list(request, "room_id")
+        if isinstance(room_ids, Response):
+            return room_ids
+
+        class_types = [
+            part.strip()
+            for raw in request.query_params.getlist("class_type")
+            for part in str(raw).split(",")
+            if part.strip()
+        ]
+
         schemas = get_schedule_schema_list(
             start_time=start_time,
-            instructor_id=instructor_id,
-            room_name=room_name,
+            end_time=end_time,
+            instructor_ids=instructor_ids or None,
+            room_name=request.query_params.get("room_name"),
+            room_ids=room_ids or None,
+            title=request.query_params.get("title"),
+            titles=class_types or None,
         )
         data = [s.model_dump() for s in schemas]
         return Response(data)


### PR DESCRIPTION
## Summary
- Public `GET /api/schedules/` now filters by date range, instructor, room, and title on the server.
- Each row includes occupancy counts and instructor/room/studio display fields so the client does not need N+1 follow-up requests.

## Test plan
- [x] `pytest apps/schedules/tests/test_schedules.py apps/schedules/tests/test_services.py apps/schedules/tests/test_views.py`
- [ ] After deploy, open Classes for a week and confirm the API request includes `start_date`/`end_date` and returns only that range


Made with [Cursor](https://cursor.com)