### PR TITLE
fix(notifications): keep pytest Mailtrap errors out of Sentry

### DIFF
--- a/adminstudio_django/settings/base.py
+++ b/adminstudio_django/settings/base.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import sys
 from pathlib import Path
 
 import sentry_sdk
@@ -39,10 +40,23 @@ SENTRY_SEND_DEFAULT_PII = os.environ.get("SENTRY_SEND_DEFAULT_PII", "True").lowe
     "yes",
     "on",
 }
-if SENTRY_DSN:
+
+
+def _is_running_tests() -> bool:
+    argv0 = Path(sys.argv[0]).name if sys.argv else ""
+    return (
+        bool(os.environ.get("PYTEST_VERSION"))
+        or "pytest" in sys.modules
+        or argv0 in {"pytest", "py.test"}
+        or any(arg == "pytest" or arg.endswith("/pytest") for arg in sys.argv)
+    )
+
+
+if SENTRY_DSN and not _is_running_tests():
     sentry_sdk.init(
         dsn=SENTRY_DSN,
         send_default_pii=SENTRY_SEND_DEFAULT_PII,
+        environment=os.environ.get("SENTRY_ENVIRONMENT") or os.environ.get("DJANGO_ENV", "local"),
         integrations=[
             LoggingIntegration(
                 level=logging.INFO,
@@ -187,10 +201,10 @@ EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD")
 EMAIL_PORT = int(os.getenv("EMAIL_PORT", 2525))
 # For Mailtrap: set EMAIL_USE_TLS=True (default port 2525 uses STARTTLS)
 EMAIL_USE_TLS = os.environ.get("EMAIL_USE_TLS", "True").lower() in {"1", "true", "yes", "on"}
-DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL")
 # Product domain for demo identities, ICS UIDs, and similar branding.
 # Override per env (local/prod) or with EMAIL_DOMAIN. Distinct from DEFAULT_FROM_EMAIL.
 EMAIL_DOMAIN = os.getenv("EMAIL_DOMAIN", "pulsefit.com")
+DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL") or f"noreply@{EMAIL_DOMAIN}"
 RESEND_API_KEY = os.getenv("RESEND_API_KEY")
 MAILTRAP_API_KEY = os.getenv("MAILTRAP_API_KEY")
 MAILTRAP_INBOX_ID = os.getenv("MAILTRAP_INBOX_ID")

--- a/apps/notifications/mailing.py
+++ b/apps/notifications/mailing.py
@@ -27,7 +27,8 @@ class Email:
         self.notification_id = notification_id
         self.subject = subject
         self.message = message
-        self.from_email = from_email or settings.DEFAULT_FROM_EMAIL
+        domain = getattr(settings, "EMAIL_DOMAIN", "pulsefit.com") or "pulsefit.com"
+        self.from_email = from_email or settings.DEFAULT_FROM_EMAIL or f"noreply@{domain}"
         self.recipient_list = recipient_list
         self.html_content = html_content
 
@@ -105,6 +106,12 @@ class Email:
         logger.info("Email send started", extra=log_base)
 
         if mailing_client == constants.MAIL_CLIENT_MAILTRAP:
+            if not (self.from_email or "").strip():
+                logger.warning(
+                    "Skipping Mailtrap send because from_email is missing",
+                    extra=log_base,
+                )
+                return
             try:
                 self._send_via_mailtrap()
             except Exception:
@@ -135,19 +142,18 @@ class Email:
                     timeout=60,  # Increased from 20 to 60 seconds
                 )
                 resp.raise_for_status()
-            except requests.exceptions.Timeout as e:
-                logger.error(
-                    "Timeout sending email via external service - service may be slow or unavailable",
-                    extra={
-                        **log_base,
-                        "error": str(e),
-                        "timeout": 60,
-                    },
+            except requests.exceptions.RequestException as e:
+                # Transient upstream failures (503 cold-start, timeouts, etc.) are expected
+                # for the free Render mailing service. Use warning so LoggingIntegration
+                # (event_level=ERROR) does not open a Sentry issue per outage.
+                logger.warning(
+                    "Failed to send email via external service",
+                    extra={**log_base, "error": str(e)},
                 )
-                # Don't raise - allow task to complete, email will be retried if needed
+                # Don't raise - allow task to complete
             except Exception as e:
                 logger.exception(
-                    "Failed to send email via external service",
+                    "Unexpected error sending email via external service",
                     extra={**log_base, "error": str(e)},
                 )
                 # Don't raise - allow task to complete

--- a/apps/notifications/tests/test_mailing.py
+++ b/apps/notifications/tests/test_mailing.py
@@ -76,6 +76,19 @@ class TestMarkNotificationAsSent:
         assert notification.status == notification.STATUS.sent
 
 
+class TestEmailFromAddress:
+    def test_falls_back_to_noreply_at_email_domain(self, settings):
+        settings.DEFAULT_FROM_EMAIL = None
+        settings.EMAIL_DOMAIN = "pulsefit.com"
+        email = Email(
+            notification_id="nid",
+            subject="subj",
+            message="msg",
+            recipient_list=["a@b.com"],
+        )
+        assert email.from_email == "noreply@pulsefit.com"
+
+
 class TestGetApiKeyForProvider:
     def test_returns_resend_key(self, settings):
         settings.RESEND_API_KEY = "RS.TEST"
@@ -188,6 +201,8 @@ class TestEmailSendMail:
 
     def test_http_error_handled_resend(self, mocker, settings):
         # Arrange
+        import requests as requests_lib
+
         settings.RESEND_API_KEY = "RS.TEST"
         settings.DEFAULT_FROM_EMAIL = "from@example.com"
         email = Email(
@@ -198,17 +213,26 @@ class TestEmailSendMail:
         )
         mocker.patch.object(Email, "get_mailing_client", return_value=constants.MAIL_CLIENT_RESEND)
 
-        # Mock post returns a response but raise_for_status raises HTTPError
+        # Upstream 503 (e.g. Render cold start) must not raise or use logger.exception
         resp = mocker.Mock()
-        resp.text = "bad"
-        resp.raise_for_status.side_effect = Exception("HTTP 500")
+        resp.text = "Service Unavailable"
+        resp.status_code = 503
+        http_error = requests_lib.exceptions.HTTPError(
+            "503 Server Error: Service Unavailable", response=resp
+        )
+        resp.raise_for_status.side_effect = http_error
         post_mock = mocker.patch("apps.notifications.mailing.requests.post", return_value=resp)
+        log_warning = mocker.patch("apps.notifications.mailing.logger.warning")
+        log_exception = mocker.patch("apps.notifications.mailing.logger.exception")
 
         # Act - should not raise
         email.send_mail()
 
-        # Assert: post called and error handled (no exception raised)
+        # Assert: post called, soft-logged as warning (not exception → no Sentry issue)
         assert post_mock.called
+        log_warning.assert_called_once()
+        assert "Failed to send email via external service" in log_warning.call_args.args[0]
+        log_exception.assert_not_called()
 
     def test_sends_via_api_for_mailtrap(self, mocker, settings):
         # Arrange
@@ -301,9 +325,9 @@ class TestEmailSendMail:
             email.send_mail()
         post_mock.assert_called_once()
 
-    def test_raises_error_when_from_email_missing_for_mailtrap(self, mocker, settings):
-        # Arrange
+    def test_skips_mailtrap_send_when_from_email_missing(self, mocker, settings):
         settings.DEFAULT_FROM_EMAIL = None
+        settings.EMAIL_DOMAIN = None
         settings.MAILTRAP_API_KEY = "MT.TEST"
         settings.MAILTRAP_USE_SANDBOX = False
         email = Email(
@@ -313,13 +337,15 @@ class TestEmailSendMail:
             recipient_list=["to@example.com"],
             from_email=None,
         )
+        email.from_email = None
         mocker.patch.object(
             Email, "get_mailing_client", return_value=constants.MAIL_CLIENT_MAILTRAP
         )
+        post_mock = mocker.patch("apps.notifications.mailing.requests.post")
 
-        # Act & Assert: ValueError should be raised
-        with pytest.raises(ValueError, match="from_email is required"):
-            email.send_mail()
+        email.send_mail()
+
+        post_mock.assert_not_called()
 
     def test_uses_sandbox_url_when_configured(self, mocker, settings):
         settings.DEFAULT_FROM_EMAIL = "from@example.com"

--- a/conftest.py
+++ b/conftest.py
@@ -2,6 +2,8 @@ import os
 
 # Ensure Django settings are configured for pytest even if pytest-django plugin isn't active
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "adminstudio_django.settings")
+# Never send pytest traffic to Sentry (local .env often has SENTRY_DSN set).
+os.environ["SENTRY_DSN"] = ""
 
 try:
     import django  # noqa: F401
@@ -24,6 +26,19 @@ if django and not os.environ.get("_DJANGO_SETUP_DONE"):
 # Shared pytest fixtures
 import pytest
 from rest_framework.test import APIClient
+
+
+@pytest.fixture(autouse=True)
+def _block_live_email_sends(request, mocker):
+    """Keep API/domain tests from hitting python-mailing / Resend / Mailtrap.
+
+    Mailing unit tests exercise Email.send_mail themselves and mock HTTP.
+    """
+    if getattr(request.module, "__name__", "") == "apps.notifications.tests.test_mailing":
+        yield
+        return
+    mocker.patch("apps.notifications.mailing.Email.send_mail", return_value=None)
+    yield
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- Promote the PULSEFIT-2 mailing/Sentry fix from develop to main.
- Pytest no longer reports Mailtrap test errors to Sentry; missing from_email no longer crashes sends.

## Test plan
- [x] CI on #58 (Black + tests)
- [ ] Production no longer receives local pytest Mailtrap events

Fixes PULSEFIT-2

Made with [Cursor](https://cursor.com)