### PR TITLE
test(notifications): cover mailing Sentry guards and transient failures

### DIFF
--- a/apps/common/tests/test_sentry_settings.py
+++ b/apps/common/tests/test_sentry_settings.py
@@ -1,7 +1,43 @@
 """Sentry bootstrap helpers used to keep pytest noise out of Sentry."""
 
-from adminstudio_django.settings.base import _is_running_tests
+import os
+import types
+
+import adminstudio_django.settings.base as base
 
 
 def test_is_running_tests_true_under_pytest():
-    assert _is_running_tests() is True
+    assert base._is_running_tests() is True
+
+
+def test_is_running_tests_detects_pytest_env(monkeypatch):
+    monkeypatch.setenv("PYTEST_VERSION", "8.3.0")
+    fake_sys = types.SimpleNamespace(argv=["manage.py", "runserver"], modules={})
+    monkeypatch.setattr(base, "sys", fake_sys)
+    assert base._is_running_tests() is True
+
+
+def test_is_running_tests_detects_pytest_argv(monkeypatch):
+    monkeypatch.delenv("PYTEST_VERSION", raising=False)
+    fake_sys = types.SimpleNamespace(argv=["/venv/bin/pytest", "-q"], modules={})
+    monkeypatch.setattr(base, "sys", fake_sys)
+    assert base._is_running_tests() is True
+
+
+def test_is_running_tests_detects_pytest_module(monkeypatch):
+    monkeypatch.delenv("PYTEST_VERSION", raising=False)
+    fake_sys = types.SimpleNamespace(argv=["manage.py", "runserver"], modules={"pytest": object()})
+    monkeypatch.setattr(base, "sys", fake_sys)
+    assert base._is_running_tests() is True
+
+
+def test_is_running_tests_false_outside_pytest(monkeypatch):
+    monkeypatch.delenv("PYTEST_VERSION", raising=False)
+    fake_sys = types.SimpleNamespace(argv=["gunicorn", "adminstudio_django.wsgi"], modules={})
+    monkeypatch.setattr(base, "sys", fake_sys)
+    assert base._is_running_tests() is False
+
+
+def test_sentry_dsn_cleared_in_conftest():
+    """Root conftest forces SENTRY_DSN empty so LoggingIntegration never fires in pytest."""
+    assert os.environ.get("SENTRY_DSN", "") == ""

--- a/apps/common/tests/test_sentry_settings.py
+++ b/apps/common/tests/test_sentry_settings.py
@@ -1,0 +1,7 @@
+"""Sentry bootstrap helpers used to keep pytest noise out of Sentry."""
+
+from adminstudio_django.settings.base import _is_running_tests
+
+
+def test_is_running_tests_true_under_pytest():
+    assert _is_running_tests() is True

--- a/apps/notifications/tests/test_email_guard.py
+++ b/apps/notifications/tests/test_email_guard.py
@@ -1,0 +1,19 @@
+"""Guards that keep pytest from hitting the live mailing service / Sentry."""
+
+from apps.notifications.mailing import Email
+
+
+def test_autouse_blocks_live_email_http(mocker):
+    """Root conftest mocks Email.send_mail outside test_mailing.py."""
+    post = mocker.patch("apps.notifications.mailing.requests.post")
+    email = Email(
+        notification_id="nid",
+        subject="subj",
+        message="msg",
+        recipient_list=["to@example.com"],
+        from_email="from@example.com",
+    )
+
+    email.send_mail()
+
+    post.assert_not_called()

--- a/apps/notifications/tests/test_mailing.py
+++ b/apps/notifications/tests/test_mailing.py
@@ -234,6 +234,58 @@ class TestEmailSendMail:
         assert "Failed to send email via external service" in log_warning.call_args.args[0]
         log_exception.assert_not_called()
 
+    def test_timeout_handled_as_warning_resend(self, mocker, settings):
+        import requests as requests_lib
+
+        settings.RESEND_API_KEY = "RS.TEST"
+        settings.DEFAULT_FROM_EMAIL = "from@example.com"
+        email = Email(
+            notification_id="123",
+            subject="Hello",
+            message="World",
+            recipient_list=["to@example.com"],
+        )
+        mocker.patch.object(Email, "get_mailing_client", return_value=constants.MAIL_CLIENT_RESEND)
+        post_mock = mocker.patch(
+            "apps.notifications.mailing.requests.post",
+            side_effect=requests_lib.exceptions.Timeout("timed out"),
+        )
+        log_warning = mocker.patch("apps.notifications.mailing.logger.warning")
+        log_exception = mocker.patch("apps.notifications.mailing.logger.exception")
+
+        email.send_mail()
+
+        assert post_mock.called
+        log_warning.assert_called_once()
+        assert "Failed to send email via external service" in log_warning.call_args.args[0]
+        log_exception.assert_not_called()
+
+    def test_connection_error_handled_as_warning_resend(self, mocker, settings):
+        import requests as requests_lib
+
+        settings.RESEND_API_KEY = "RS.TEST"
+        settings.DEFAULT_FROM_EMAIL = "from@example.com"
+        email = Email(
+            notification_id="123",
+            subject="Hello",
+            message="World",
+            recipient_list=["to@example.com"],
+        )
+        mocker.patch.object(Email, "get_mailing_client", return_value=constants.MAIL_CLIENT_RESEND)
+        post_mock = mocker.patch(
+            "apps.notifications.mailing.requests.post",
+            side_effect=requests_lib.exceptions.ConnectionError("connection refused"),
+        )
+        log_warning = mocker.patch("apps.notifications.mailing.logger.warning")
+        log_exception = mocker.patch("apps.notifications.mailing.logger.exception")
+
+        email.send_mail()
+
+        assert post_mock.called
+        log_warning.assert_called_once()
+        assert "Failed to send email via external service" in log_warning.call_args.args[0]
+        log_exception.assert_not_called()
+
     def test_sends_via_api_for_mailtrap(self, mocker, settings):
         # Arrange
         settings.DEFAULT_FROM_EMAIL = "from@example.com"
@@ -342,10 +394,13 @@ class TestEmailSendMail:
             Email, "get_mailing_client", return_value=constants.MAIL_CLIENT_MAILTRAP
         )
         post_mock = mocker.patch("apps.notifications.mailing.requests.post")
+        log_warning = mocker.patch("apps.notifications.mailing.logger.warning")
 
         email.send_mail()
 
         post_mock.assert_not_called()
+        log_warning.assert_called_once()
+        assert "from_email is missing" in log_warning.call_args.args[0]
 
     def test_uses_sandbox_url_when_configured(self, mocker, settings):
         settings.DEFAULT_FROM_EMAIL = "from@example.com"


### PR DESCRIPTION
## Summary
- Cover `_is_running_tests()` (env/argv/module/false paths) and assert conftest clears `SENTRY_DSN`.
- Smoke-test the root autouse that blocks live `Email.send_mail` outside mailing unit tests.
- Extend mailing tests for timeout/connection errors (warning, not exception) and Mailtrap missing-`from_email` skip.

## Test plan
- [x] `pytest -q apps/common/tests/test_sentry_settings.py apps/notifications/tests/test_email_guard.py apps/notifications/tests/test_mailing.py`

Fixes PULSEFIT-4