### PR TITLE
fix(notifications): skip missing-email sends without Sentry issues

### DIFF
--- a/apps/notifications/mailing.py
+++ b/apps/notifications/mailing.py
@@ -188,7 +188,9 @@ def send_pending_emails(notifications: list[dict[str, str]]):
 
         user = get_user_from_id(notification.user_id)
         if not user.get("email"):
-            logger.error(
+            # Expected skip (users without email). Use warning so LoggingIntegration
+            # (event_level=ERROR) does not open a Sentry issue.
+            logger.warning(
                 "Skipping notification because user has no email",
                 extra={
                     "notification_id": str(notification.id),

--- a/apps/notifications/tests/test_mailing.py
+++ b/apps/notifications/tests/test_mailing.py
@@ -52,6 +52,8 @@ class TestSendPendingEmails:
         )
         email_send = mocker.patch("apps.notifications.mailing.Email.send_mail")
         mark_sent = mocker.patch("apps.notifications.mailing.mark_notification_as_sent")
+        log_warning = mocker.patch("apps.notifications.mailing.logger.warning")
+        log_error = mocker.patch("apps.notifications.mailing.logger.error")
 
         # Act
         send_pending_emails([notification])
@@ -59,6 +61,9 @@ class TestSendPendingEmails:
         # Assert: no email sent and not marked as sent
         email_send.assert_not_called()
         mark_sent.assert_not_called()
+        log_warning.assert_called_once()
+        assert "Skipping notification because user has no email" in log_warning.call_args.args[0]
+        log_error.assert_not_called()
 
 
 class TestMarkNotificationAsSent:


### PR DESCRIPTION
## Summary
- Users without an email are expected to skip outbound mail. That path used `logger.error`, which Sentry's LoggingIntegration records as an issue (PULSEFIT-3).
- Log the skip as a warning so it stays visible in logs without opening a Sentry error.

## Test plan
- [x] `pytest apps/notifications/tests/test_mailing.py::TestSendPendingEmails`
- [ ] Confirm PULSEFIT-3 does not recur after deploy

Fixes PULSEFIT-3
