### PR TITLE
fix(notifications): style password recovery and waitlist emails

### DIFF
--- a/apps/members/waitlist.py
+++ b/apps/members/waitlist.py
@@ -165,27 +165,47 @@ def confirm_waitlist_offer(*, user_id: str | UUID, waitlist_id: str | UUID) -> W
 
 
 def _notify_waitlist_offer(entry: WaitlistEntry, auto_confirmed: bool) -> None:
+    from django.conf import settings
+
+    from apps.notifications.email_templates import render_waitlist_offer
     from apps.notifications.services import create_notification
 
     user = entry.member.user
     schedule = entry.schedule
     title = schedule.title or "clase"
     start = timezone.localtime(schedule.start_time).strftime("%d/%m/%Y %H:%M")
+    frontend_url = (getattr(settings, "FRONTEND_URL", None) or "http://localhost:5173").rstrip("/")
+    minutes = constants.WAITLIST_OFFER_MINUTES
+    spot = entry.offered_spot
     if auto_confirmed:
         subject = f"Spot confirmado en {title}"
         message = (
             f"Se liberó un cupo en {title} ({start}). "
-            f"Como tienes auto-confirmación activa, reservamos el spot {entry.offered_spot} por ti."
+            f"Como tienes auto-confirmación activa, reservamos el spot {spot} por ti."
         )
+        action_url = f"{frontend_url}/#my-reservations"
     else:
-        minutes = constants.WAITLIST_OFFER_MINUTES
         subject = f"Se liberó un spot en {title}"
         message = (
             f"Se liberó un cupo en {title} ({start}). "
-            f"Tienes {minutes} minutos para confirmar tu spot {entry.offered_spot} "
+            f"Tienes {minutes} minutos para confirmar tu spot {spot} "
             "desde Lista de espera en PulseFit."
         )
-    create_notification(subject, message, [user])
+        action_url = f"{frontend_url}/#waitlist"
+    create_notification(
+        subject,
+        message,
+        [user],
+        html_content=render_waitlist_offer(
+            class_title=title,
+            when_label=start,
+            spot=spot,
+            action_url=action_url,
+            frontend_url=frontend_url,
+            auto_confirmed=auto_confirmed,
+            offer_minutes=minutes,
+        ),
+    )
 
 
 def _convert_waitlist_entry(entry: WaitlistEntry, spot: int) -> WaitlistEntry:

--- a/apps/notifications/email_templates.py
+++ b/apps/notifications/email_templates.py
@@ -291,3 +291,78 @@ def render_purchase_receipt(
 </p>
 """
     return _shell(preheader=preheader, body_html=body, frontend_url=frontend_url)
+
+
+def _code_block(code: str) -> str:
+    return f"""
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="width:100%;margin:8px 0 24px">
+  <tr>
+    <td align="center" style="padding:20px 16px;background-color:{BG};border:1px solid {BORDER};border-radius:8px">
+      <span style="font-family:{FONT};font-size:32px;font-weight:700;letter-spacing:0.28em;color:{DARK}">
+        {escape(code)}
+      </span>
+    </td>
+  </tr>
+</table>
+"""
+
+
+def render_password_recovery(
+    *,
+    reset_code: str,
+    frontend_url: str,
+    expiration_minutes: int = 5,
+) -> str:
+    body = f"""
+<h1 style="margin:0 0 12px;font-family:{FONT};font-size:24px;font-weight:700;line-height:32px;color:{DARK}">Recupera tu contraseña</h1>
+<p style="margin:0 0 16px;font-family:{FONT};font-size:15px;line-height:24px;color:{TEXT}">
+  Usa este código en PulseFit para elegir una nueva contraseña. No lo compartas con nadie.
+</p>
+{_code_block(reset_code)}
+{_notice_box(f"Caduca en {int(expiration_minutes)} minutos.", tone="info")}
+<p style="margin:0 0 16px;font-family:{FONT};font-size:15px;line-height:24px;color:{MUTED}">
+  Si no pediste recuperar tu cuenta, ignora este mensaje. Tu contraseña no cambia hasta que ingreses el código.
+</p>
+"""
+    return _shell(
+        preheader=f"Tu código es {reset_code}. Caduca en {int(expiration_minutes)} minutos.",
+        body_html=body,
+        frontend_url=frontend_url,
+    )
+
+
+def render_waitlist_offer(
+    *,
+    class_title: str,
+    when_label: str,
+    spot: int,
+    action_url: str,
+    frontend_url: str,
+    auto_confirmed: bool = False,
+    offer_minutes: int = 15,
+) -> str:
+    if auto_confirmed:
+        body = f"""
+<h1 style="margin:0 0 12px;font-family:{FONT};font-size:24px;font-weight:700;line-height:32px;color:{DARK}">Spot confirmado</h1>
+<p style="margin:0 0 16px;font-family:{FONT};font-size:15px;line-height:24px;color:{TEXT}">
+  Se liberó un cupo en <strong>{escape(class_title)}</strong> ({escape(when_label)}).
+  Como tienes auto-confirmación activa, reservamos el spot {int(spot)} por ti.
+</p>
+{_notice_box(f"Spot {int(spot)} reservado automáticamente.", tone="success")}
+{_cta_button(action_url, "Ver mi reserva")}
+"""
+        preheader = f"Spot {int(spot)} confirmado en {class_title}."
+    else:
+        body = f"""
+<h1 style="margin:0 0 12px;font-family:{FONT};font-size:24px;font-weight:700;line-height:32px;color:{DARK}">Se liberó un spot</h1>
+<p style="margin:0 0 16px;font-family:{FONT};font-size:15px;line-height:24px;color:{TEXT}">
+  Hay un cupo disponible en <strong>{escape(class_title)}</strong> ({escape(when_label)}).
+  Confirma el spot {int(spot)} desde Lista de espera antes de que expire la oferta.
+</p>
+{_notice_box(f"Tienes {int(offer_minutes)} minutos para confirmar.", tone="info")}
+{_cta_button(action_url, "Ir a lista de espera")}
+"""
+        preheader = (
+            f"Spot {int(spot)} libre en {class_title}. Confirma en {int(offer_minutes)} min."
+        )
+    return _shell(preheader=preheader, body_html=body, frontend_url=frontend_url)

--- a/apps/notifications/tests/test_email_templates.py
+++ b/apps/notifications/tests/test_email_templates.py
@@ -1,7 +1,9 @@
 from apps.notifications.email_templates import (
     render_booking_confirmed,
     render_class_cancelled,
+    render_password_recovery,
     render_purchase_receipt,
+    render_waitlist_offer,
 )
 
 
@@ -78,3 +80,51 @@ def test_render_purchase_receipt_matches_sketch_copy():
         in html
     )
     assert "Pago recibido. 10 créditos válidos 90 días desde hoy." in html
+
+
+def test_render_password_recovery_matches_sketch_copy():
+    html = render_password_recovery(
+        reset_code="CLJDOL",
+        frontend_url="http://localhost:5173",
+        expiration_minutes=5,
+    )
+
+    assert "Recupera tu contraseña" in html
+    assert "CLJDOL" in html
+    assert "Caduca en 5 minutos." in html
+    assert "PulseFit Studio" in html
+    assert "UUID" not in html
+
+
+def test_render_waitlist_offer_pending():
+    html = render_waitlist_offer(
+        class_title="Power Ride 45",
+        when_label="27/08/2026 19:00",
+        spot=12,
+        action_url="http://localhost:5173/#waitlist",
+        frontend_url="http://localhost:5173",
+        auto_confirmed=False,
+        offer_minutes=15,
+    )
+
+    assert "Se liberó un spot" in html
+    assert "Power Ride 45" in html
+    assert "Tienes 15 minutos para confirmar." in html
+    assert "Ir a lista de espera" in html
+    assert "#waitlist" in html
+
+
+def test_render_waitlist_offer_auto_confirmed():
+    html = render_waitlist_offer(
+        class_title="Power Ride 45",
+        when_label="27/08/2026 19:00",
+        spot=12,
+        action_url="http://localhost:5173/#my-reservations",
+        frontend_url="http://localhost:5173",
+        auto_confirmed=True,
+    )
+
+    assert "Spot confirmado" in html
+    assert "auto-confirmación activa" in html
+    assert "Ver mi reserva" in html
+    assert "#my-reservations" in html

--- a/apps/users/services.py
+++ b/apps/users/services.py
@@ -165,22 +165,27 @@ def send_password_recovery_email(user: User, reset_code_uuid: str | UUID, reset_
 
     Args:
         user: The user requesting password recovery.
-        reset_code_uuid: The UUID of the password reset code.
+        reset_code_uuid: Unused by the template; kept for call-site compatibility.
         reset_code: The 6-character reset code.
     """
+    del reset_code_uuid  # call sites still pass the PasswordResetCode id
     # Import here to avoid circular import
+    from apps.notifications.email_templates import render_password_recovery
     from apps.notifications.services import create_notification
 
+    minutes = settings.VERIFICATION_CODE_EXPIRATION_MINUTES
+    frontend_url = _frontend_url()
     subject = "Recuperación de contraseña"
-    message = (
-        f"Tu código de recuperación es: {reset_code} y expira en "
-        f"{settings.VERIFICATION_CODE_EXPIRATION_MINUTES} minutos. "
-        f"UUID: {reset_code_uuid}"
-    )
+    message = f"Tu código de recuperación es: {reset_code} y expira en {minutes} minutos."
     create_notification(
         subject=subject,
         message=message,
         recipient_list=[user],
+        html_content=render_password_recovery(
+            reset_code=reset_code,
+            frontend_url=frontend_url,
+            expiration_minutes=minutes,
+        ),
     )
 
 


### PR DESCRIPTION
## Summary
- Add HTML templates for password recovery and waitlist offer/auto-confirm emails using the existing PulseFit shell.
- Drop the raw UUID from the recovery email body (users only need the 6-char code).
- Keep plain-text fallbacks for clients that do not render HTML.

## Test plan
- [x] `pytest apps/notifications/tests/test_email_templates.py apps/users/tests/test_services.py apps/members/tests/test_waitlist.py`
- [ ] Request password recovery and confirm the message arrives with PulseFit branding and a large code block
- [ ] Trigger a waitlist offer and confirm HTML + CTA to `#waitlist` / `#my-reservations`


Made with [Cursor](https://cursor.com)